### PR TITLE
Add type annotations for public APIs and CLI entrypoints

### DIFF
--- a/tensorqtl/core.py
+++ b/tensorqtl/core.py
@@ -1,71 +1,89 @@
-import torch
-import numpy as np
-import pandas as pd
-import scipy.stats as stats
-import scipy.optimize
-from scipy.special import loggamma
-import sys
+import os
 import re
 import subprocess
+import sys
+from collections.abc import Sequence
+from typing import Any
+
+import numpy as np
+import pandas as pd
+import scipy.optimize
+import scipy.stats as stats
+import torch
+from scipy.special import loggamma
 
 # check R
 has_rpy2 = False
+rfunc = None
 try:
-    subprocess.check_call('which R', shell=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
-    subprocess.check_call("R -e 'library(qvalue)'", shell=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
-    import rpy2
+    subprocess.check_call(
+        "which R", shell=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL
+    )
+    subprocess.check_call(
+        "R -e 'library(qvalue)'",
+        shell=True,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
     import rfunc
+    import rpy2
+
     has_rpy2 = True
 except:
-    print("Warning: 'rfunc' cannot be imported. R with the 'qvalue' library and the 'rpy2' Python package are needed to compute q-values.")
+    print(
+        "Warning: 'rfunc' cannot be imported. R with the 'qvalue' library and the 'rpy2' Python package are needed to compute q-values."
+    )
 
 
 output_dtype_dict = {
-    'num_var':np.int32,
-    'beta_shape1':np.float32,
-    'beta_shape2':np.float32,
-    'true_df':np.float32,
-    'pval_true_df':np.float64,
-    'variant_id':str,
-    'start_distance':np.int32,
-    'end_distance':np.int32,
-    'ma_samples':np.int32,
-    'ma_count':np.int32,
-    'af':np.float32,
-    'pval_nominal':np.float64,
-    'slope':np.float32,
-    'slope_se':np.float32,
-    'pval_perm':np.float64,
-    'pval_beta':np.float64,
+    "num_var": np.int32,
+    "beta_shape1": np.float32,
+    "beta_shape2": np.float32,
+    "true_df": np.float32,
+    "pval_true_df": np.float64,
+    "variant_id": str,
+    "start_distance": np.int32,
+    "end_distance": np.int32,
+    "ma_samples": np.int32,
+    "ma_count": np.int32,
+    "af": np.float32,
+    "pval_nominal": np.float64,
+    "slope": np.float32,
+    "slope_se": np.float32,
+    "pval_perm": np.float64,
+    "pval_beta": np.float64,
 }
 
 
 class SimpleLogger(object):
-    def __init__(self, logfile=None, verbose=True):
+    def __init__(
+        self, logfile: os.PathLike[str] | str | None = None, verbose: bool = True
+    ):
         self.console = sys.stdout
         self.verbose = verbose
         if logfile is not None:
-            self.log = open(logfile, 'w')
+            self.log = open(logfile, "w")
         else:
             self.log = None
 
-    def write(self, message):
+    def write(self, message: str):
         if self.verbose:
-            self.console.write(message+'\n')
+            self.console.write(message + "\n")
         if self.log is not None:
-            self.log.write(message+'\n')
+            self.log.write(message + "\n")
             self.log.flush()
 
-#------------------------------------------------------------------------------
+
+# ------------------------------------------------------------------------------
 #  Core classes/functions for mapping associations on GPU
-#------------------------------------------------------------------------------
+# ------------------------------------------------------------------------------
 class Residualizer(object):
-    def __init__(self, C_t):
+    def __init__(self, C_t: torch.Tensor) -> None:
         # center and orthogonalize
         self.Q_t, _ = torch.linalg.qr(C_t - C_t.mean(0))
         self.dof = C_t.shape[0] - 2 - C_t.shape[1]
 
-    def transform(self, M_t, center=True):
+    def transform(self, M_t: torch.Tensor, center: bool = True) -> torch.Tensor:
         """Residualize rows of M wrt columns of C"""
         M0_t = M_t - M_t.mean(1, keepdim=True)
         if center:
@@ -75,13 +93,15 @@ class Residualizer(object):
         return M0_t
 
 
-def calculate_maf(genotype_t, alleles=2):
+def calculate_maf(genotype_t: torch.Tensor, alleles: int = 2) -> torch.Tensor:
     """Calculate minor allele frequency"""
     af_t = genotype_t.sum(1) / (alleles * genotype_t.shape[1])
     return torch.where(af_t > 0.5, 1 - af_t, af_t)
 
 
-def get_allele_stats(genotype_t):
+def get_allele_stats(
+    genotype_t: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     """Returns allele frequency, minor allele samples, and minor allele counts (row-wise)."""
     # allele frequency
     n2 = 2 * genotype_t.shape[1]
@@ -94,11 +114,16 @@ def get_allele_stats(genotype_t):
     ma_samples_t = torch.where(ix_t, a, b)
     a = (genotype_t * m.float()).sum(1).int()
     # a = (genotype_t * m.float()).sum(1).round().int()  # round for missing/imputed genotypes
-    ma_count_t = torch.where(ix_t, a, n2-a)
+    ma_count_t = torch.where(ix_t, a, n2 - a)
     return af_t, ma_samples_t, ma_count_t
 
 
-def filter_maf(genotypes_t, variant_ids, maf_threshold, alleles=2):
+def filter_maf(
+    genotypes_t: torch.Tensor,
+    variant_ids: Any,
+    maf_threshold: float,
+    alleles: int = 2,
+) -> tuple[torch.Tensor, Any, torch.Tensor]:
     """Calculate MAF and filter genotypes that don't pass threshold"""
     af_t = genotypes_t.sum(1) / (alleles * genotypes_t.shape[1])
     maf_t = torch.where(af_t > 0.5, 1 - af_t, af_t)
@@ -110,35 +135,54 @@ def filter_maf(genotypes_t, variant_ids, maf_threshold, alleles=2):
     return genotypes_t, variant_ids, af_t
 
 
-def filter_maf_interaction(genotypes_t, interaction_mask_t=None, maf_threshold_interaction=0.05):
+def filter_maf_interaction(
+    genotypes_t: torch.Tensor,
+    interaction_mask_t: torch.Tensor | None = None,
+    maf_threshold_interaction: float = 0.05,
+) -> tuple[torch.Tensor, torch.Tensor]:
     # filter monomorphic sites (to avoid colinearity)
-    mask_t = ~((genotypes_t==0).all(1) | (genotypes_t==1).all(1) | (genotypes_t==2).all(1))
+    mask_t = ~(
+        (genotypes_t == 0).all(1)
+        | (genotypes_t == 1).all(1)
+        | (genotypes_t == 2).all(1)
+    )
     if interaction_mask_t is not None:
-        upper_t = calculate_maf(genotypes_t[:, interaction_mask_t]) >= maf_threshold_interaction - 1e-7
-        lower_t = calculate_maf(genotypes_t[:,~interaction_mask_t]) >= maf_threshold_interaction - 1e-7
+        upper_t = (
+            calculate_maf(genotypes_t[:, interaction_mask_t])
+            >= maf_threshold_interaction - 1e-7
+        )
+        lower_t = (
+            calculate_maf(genotypes_t[:, ~interaction_mask_t])
+            >= maf_threshold_interaction - 1e-7
+        )
         mask_t = mask_t & upper_t & lower_t
     genotypes_t = genotypes_t[mask_t]
     return genotypes_t, mask_t
 
 
-def impute_mean(genotypes_t, missing=-9):
+def impute_mean(genotypes_t: torch.Tensor, missing: int | float = -9) -> None:
     """Impute missing genotypes to mean"""
     m = genotypes_t == missing
     ix = torch.nonzero(m, as_tuple=True)[0]
     if len(ix) > 0:
         a = genotypes_t.sum(1)
         b = m.sum(1).float()
-        mu = (a - missing*b) / (genotypes_t.shape[1] - b)
+        mu = (a - missing * b) / (genotypes_t.shape[1] - b)
         genotypes_t[m] = mu[ix]
 
 
-def center_normalize(M_t, dim=0):
+def center_normalize(M_t: torch.Tensor, dim: int = 0) -> torch.Tensor:
     """Center and normalize M"""
     N_t = M_t - M_t.mean(dim=dim, keepdim=True)
     return N_t / torch.sqrt(torch.pow(N_t, 2).sum(dim=dim, keepdim=True))
 
 
-def calculate_corr(genotype_t, phenotype_t, residualizer=None, return_var=False):
+def calculate_corr(
+    genotype_t: torch.Tensor,
+    phenotype_t: torch.Tensor,
+    residualizer: Residualizer | None = None,
+    return_var: bool = False,
+) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     """Calculate correlation between normalized residual genotypes and phenotypes"""
 
     # residualize
@@ -152,19 +196,21 @@ def calculate_corr(genotype_t, phenotype_t, residualizer=None, return_var=False)
     if return_var:
         genotype_var_t = genotype_res_t.var(1)
         phenotype_var_t = phenotype_res_t.var(1)
-
-    # center and normalize
-    genotype_res_t = center_normalize(genotype_res_t, dim=1)
-    phenotype_res_t = center_normalize(phenotype_res_t, dim=1)
-
-    # correlation
-    if return_var:
-        return torch.mm(genotype_res_t, phenotype_res_t.t()), genotype_var_t, phenotype_var_t
+        genotype_res_t = center_normalize(genotype_res_t, dim=1)
+        phenotype_res_t = center_normalize(phenotype_res_t, dim=1)
+        return (
+            torch.mm(genotype_res_t, phenotype_res_t.t()),
+            genotype_var_t,
+            phenotype_var_t,
+        )
     else:
+        # center and normalize
+        genotype_res_t = center_normalize(genotype_res_t, dim=1)
+        phenotype_res_t = center_normalize(phenotype_res_t, dim=1)
         return torch.mm(genotype_res_t, phenotype_res_t.t())
 
 
-def get_t_pval(t, df, log=False):
+def get_t_pval(t: Any, df: Any, log: bool = False) -> Any:
     """
     Get p-value corresponding to t statistic and degrees of freedom (df). t and/or df can be arrays.
     If log=True, returns -log10(P).
@@ -173,13 +219,23 @@ def get_t_pval(t, df, log=False):
         return 2 * stats.t.cdf(-abs(t), df)
     else:
         if has_rpy2:
-            return -(rfunc.t_cdf(-abs(t), df, lower_tail=True, log=True) + np.log(2)) * np.log10(np.e)
+            assert rfunc is not None
+            return -(
+                rfunc.t_cdf(-abs(t), df, lower_tail=True, log=True) + np.log(2)
+            ) * np.log10(np.e)
         else:
             raise ValueError("R and rpy2 are required to compute -log10(P)")
 
 
-def calculate_interaction_nominal(genotypes_t, phenotypes_t, interaction_t, residualizer=None,
-                                  return_sparse=False, tstat_threshold=None, variant_ids=None):
+def calculate_interaction_nominal(
+    genotypes_t: torch.Tensor,
+    phenotypes_t: torch.Tensor,
+    interaction_t: torch.Tensor,
+    residualizer: Residualizer | None = None,
+    return_sparse: bool = False,
+    tstat_threshold: float | None = None,
+    variant_ids: Sequence[str] | None = None,
+) -> tuple[torch.Tensor, ...]:
     """
     Solve y ~ g + i + g:i, where i is an interaction vector or matrix
 
@@ -203,7 +259,9 @@ def calculate_interaction_nominal(genotypes_t, phenotypes_t, interaction_t, resi
 
     # centered inputs
     g0_t = genotypes_t - genotypes_t.mean(1, keepdim=True)  # genotypes x samples
-    gi_t = (genotypes_t.unsqueeze(2) * interaction_t.unsqueeze(0))  # genotypes x samples x interactions
+    gi_t = genotypes_t.unsqueeze(2) * interaction_t.unsqueeze(
+        0
+    )  # genotypes x samples x interactions
     gi0_t = gi_t - gi_t.mean(1, keepdim=True)  # mean across samples
     i0_t = interaction_t - interaction_t.mean(0)  # samples x interactions
     p0_t = phenotypes_t - phenotypes_t.mean(1, keepdim=True)  # 1 x samples
@@ -220,28 +278,36 @@ def calculate_interaction_nominal(genotypes_t, phenotypes_t, interaction_t, resi
     # regression (in float; loss of precision may occur in edge cases)
     X_t = torch.cat([g0_t.unsqueeze(-1), i0_t, gi0_t], 2)  # ng x ns x (1+2*ni)
     try:
-        Xinv = torch.matmul(torch.transpose(X_t, 1, 2), X_t).inverse() # ng x (1+2*ni) x (1+2*ni)
+        Xinv = torch.matmul(
+            torch.transpose(X_t, 1, 2), X_t
+        ).inverse()  # ng x (1+2*ni) x (1+2*ni)
     except Exception as e:
         if variant_ids is not None and len(e.args) >= 1:
-            i = int(re.findall('For batch (\d+)', str(e))[0])
-            e.args = (e.args[0] + f'\n    Likely problematic variant: {variant_ids[i]} ',) + e.args[1:]
+            i = int(re.findall(r"For batch (\d+)", str(e))[0])
+            e.args = (
+                e.args[0] + f"\n    Likely problematic variant: {variant_ids[i]} ",
+            ) + e.args[1:]
         raise
 
     p0_tile_t = p0_t.unsqueeze(0).expand([ng, *p0_t.shape])  # ng x np x ns
 
     # calculate b, b_se
     # [(ng x nb x nb) x (ng x nb x ns)] x (ng x ns x np) = (ng x nb x np)
-    b_t = torch.matmul(torch.matmul(Xinv, torch.transpose(X_t, 1, 2)), torch.transpose(p0_tile_t, 1, 2))
+    b_t = torch.matmul(
+        torch.matmul(Xinv, torch.transpose(X_t, 1, 2)), torch.transpose(p0_tile_t, 1, 2)
+    )
     nb = b_t.shape[1]
     # residualizer.dof already includes intercept, b_g, add b_i and b_gi for each interaction
     if residualizer is not None:
-        dof = residualizer.dof - 2*ni
+        dof = residualizer.dof - 2 * ni
     else:
-        dof = phenotypes_t.shape[1] - 2 - 2*ni
+        dof = phenotypes_t.shape[1] - 2 - 2 * ni
     if nps == 1:  # single phenotype case
         r_t = torch.matmul(X_t, b_t).squeeze() - p0_t
-        rss_t = (r_t*r_t).sum(1)
-        b_se_t = torch.sqrt(Xinv[:, torch.eye(nb, dtype=torch.uint8).bool()] * rss_t.unsqueeze(1) / dof)
+        rss_t = (r_t * r_t).sum(1)
+        b_se_t = torch.sqrt(
+            Xinv[:, torch.eye(nb, dtype=torch.uint8).bool()] * rss_t.unsqueeze(1) / dof
+        )
         b_t = b_t.squeeze(2)
         # r_t = tf.squeeze(tf.matmul(X_t, b_t)) - p0_t  # (ng x ns x 3) x (ng x 3 x 1)
         # rss_t = tf.reduce_sum(tf.multiply(r_t, r_t), axis=1)
@@ -249,9 +315,17 @@ def calculate_interaction_nominal(genotypes_t, phenotypes_t, interaction_t, resi
     else:
         # b_t = tf.matmul(p0_tile_t, tf.matmul(Xinv, X_t, transpose_b=True), transpose_b=True)
         # convert to ng x np x 3??
-        r_t = torch.matmul(X_t, b_t) - torch.transpose(p0_tile_t, 1, 2)  # (ng x ns x np)
-        rss_t = (r_t*r_t).sum(1)  # ng x np
-        b_se_t = torch.sqrt(Xinv[:, torch.eye(nb, dtype=torch.uint8).bool()].unsqueeze(-1).repeat([1,1,nps]) * rss_t.unsqueeze(1).repeat([1,3,1]) / dof)
+        r_t = torch.matmul(X_t, b_t) - torch.transpose(
+            p0_tile_t, 1, 2
+        )  # (ng x ns x np)
+        rss_t = (r_t * r_t).sum(1)  # ng x np
+        b_se_t = torch.sqrt(
+            Xinv[:, torch.eye(nb, dtype=torch.uint8).bool()]
+            .unsqueeze(-1)
+            .repeat([1, 1, nps])
+            * rss_t.unsqueeze(1).repeat([1, 3, 1])
+            / dof
+        )
         # b_se_t = tf.sqrt(tf.tile(tf.expand_dims(tf.matrix_diag_part(Xinv), 2), [1,1,nps]) * tf.tile(tf.expand_dims(rss_t, 1), [1,3,1]) / dof) # (ng x 3) -> (ng x 3 x np)
 
     tstat_t = (b_t.double() / b_se_t.double()).float()  # (ng x nb x np)
@@ -265,20 +339,25 @@ def calculate_interaction_nominal(genotypes_t, phenotypes_t, interaction_t, resi
 
     else:  # sparse output
         if ni > 1:
-            raise NotImplementedError("Sparse mode not yet supported for >1 interactions")
-        af_t = genotypes_t.sum(1) / (2*ns)
-        tstat_g_t =  tstat_t[:,0,:]  # genotypes x phenotypes
-        tstat_i_t =  tstat_t[:,1,:]
-        tstat_gi_t = tstat_t[:,2,:]
+            raise NotImplementedError(
+                "Sparse mode not yet supported for >1 interactions"
+            )
+        af_t = genotypes_t.sum(1) / (2 * ns)
+        tstat_g_t = tstat_t[:, 0, :]  # genotypes x phenotypes
+        tstat_i_t = tstat_t[:, 1, :]
+        tstat_gi_t = tstat_t[:, 2, :]
+        assert tstat_threshold is not None
         m = tstat_gi_t.abs() >= tstat_threshold
         tstat_g_t = tstat_g_t[m]
         tstat_i_t = tstat_i_t[m]
         tstat_gi_t = tstat_gi_t[m]
         ix = m.nonzero(as_tuple=False)  # indexes: [genotype, phenotype]
-        return tstat_g_t, tstat_i_t, tstat_gi_t, af_t[ix[:,0]], ix
+        return tstat_g_t, tstat_i_t, tstat_gi_t, af_t[ix[:, 0]], ix
 
 
-def linreg(X_t, y_t, dtype=torch.float64):
+def linreg(
+    X_t: torch.Tensor, y_t: torch.Tensor, dtype: torch.dtype = torch.float64
+) -> tuple[torch.Tensor, torch.Tensor]:
     """
     Robust linear regression. Solves y = Xb, standardizing X.
     The first column of X must be the intercept.
@@ -300,8 +379,10 @@ def linreg(X_t, y_t, dtype=torch.float64):
     # compute s.e.
     dof = X_t.shape[0] - X_t.shape[1]
     r_t = y_t - torch.matmul(Xtilde_t, b_t)
-    sigma2_t = (r_t*r_t).sum() / dof
-    XtX_inv_t = torch.linalg.solve(XtX_t, torch.eye(X_t.shape[1], dtype=dtype).to(X_t.device))
+    sigma2_t = (r_t * r_t).sum() / dof
+    XtX_inv_t = torch.linalg.solve(
+        XtX_t, torch.eye(X_t.shape[1], dtype=dtype).to(X_t.device)
+    )
     var_b_t = sigma2_t * XtX_inv_t
     b_se_t = torch.sqrt(torch.diag(var_b_t))
 
@@ -312,12 +393,18 @@ def linreg(X_t, y_t, dtype=torch.float64):
     # adjust intercept
     b_t[0] -= torch.sum(x_mean_t * b_t)
     ms_t = x_mean_t / x_std_t
-    b_se_t[0] = torch.sqrt(b_se_t[0]**2 + torch.matmul(torch.matmul(ms_t.T, var_b_t), ms_t))
+    b_se_t[0] = torch.sqrt(
+        b_se_t[0] ** 2 + torch.matmul(torch.matmul(ms_t.T, var_b_t), ms_t)
+    )
 
     return b_t, b_se_t
 
 
-def filter_covariates(covariates_t, log_counts_t, tstat_threshold=2):
+def filter_covariates(
+    covariates_t: torch.Tensor,
+    log_counts_t: torch.Tensor,
+    tstat_threshold: int | float = 2,
+) -> torch.Tensor:
     """
     Inputs:
       covariates0_t: covariates matrix (samples x covariates)
@@ -325,7 +412,7 @@ def filter_covariates(covariates_t, log_counts_t, tstat_threshold=2):
                      ** with intercept in first column **
       log_counts_t:  counts vector (samples)
     """
-    assert (covariates_t[:,0] == 0).all()
+    assert (covariates_t[:, 0] == 0).all()
     b_t, b_se_t = linreg(covariates_t, log_counts_t)
     tstat_t = b_t / b_se_t
     m = tstat_t.abs() > tstat_threshold
@@ -333,32 +420,41 @@ def filter_covariates(covariates_t, log_counts_t, tstat_threshold=2):
     return covariates_t[:, m]
 
 
-#------------------------------------------------------------------------------
+# ------------------------------------------------------------------------------
 #  Functions for beta-approximating empirical p-values
-#------------------------------------------------------------------------------
-def pval_from_corr(r2, dof, logp=False):
+# ------------------------------------------------------------------------------
+def pval_from_corr(r2: Any, dof: Any, logp: bool = False) -> Any:
     tstat2 = dof * r2 / (1 - r2)
     return get_t_pval(np.sqrt(tstat2), dof, log=logp)
 
 
-def beta_shape_1_from_dof(r2, dof):
+def beta_shape_1_from_dof(r2: Any, dof: Any) -> Any:
     """compute the Beta shape 1 parameter from moment matching"""
     pval = pval_from_corr(r2, dof)
     mean = np.mean(pval)
     var = np.var(pval)
-    return mean * (mean * (1.0-mean) / var - 1.0)
+    return mean * (mean * (1.0 - mean) / var - 1.0)
 
 
-def beta_log_likelihood(x, shape1, shape2):
+def beta_log_likelihood(x: Any, shape1: Any, shape2: Any) -> Any:
     """negative log-likelihood of beta distribution"""
-    logbeta = loggamma(shape1) + loggamma(shape2) - loggamma(shape1+shape2)
-    return (1.0-shape1)*np.sum(np.log(x)) + (1.0-shape2)*np.sum(np.log(1.0-x)) + len(x)*logbeta
+    logbeta = loggamma(shape1) + loggamma(shape2) - loggamma(shape1 + shape2)
+    return (
+        (1.0 - shape1) * np.sum(np.log(x))
+        + (1.0 - shape2) * np.sum(np.log(1.0 - x))
+        + len(x) * logbeta
+    )
 
 
-def fit_beta_parameters(r2_perm, dof_init, tol=1e-4, return_minp=False):
+def fit_beta_parameters(
+    r2_perm: Any,
+    dof_init: float | int,
+    tol: float = 1e-4,
+    return_minp: bool = False,
+) -> tuple[Any, ...]:
     """
-      r2_perm:    array of max. r2 values from permutations
-      dof_init:   degrees of freedom
+    r2_perm:    array of max. r2 values from permutations
+    dof_init:   degrees of freedom
     """
     try:
         # Find the degrees of freedom such that the first beta parameter is
@@ -366,21 +462,36 @@ def fit_beta_parameters(r2_perm, dof_init, tol=1e-4, return_minp=False):
         # as a function of r2_perm and dof is 0.  Optimizing log(beta shape 1)
         # with a parameterization of log(dof) makes this close to a linear
         # function.
-        log_true_dof = scipy.optimize.newton(lambda x: np.log(beta_shape_1_from_dof(r2_perm, np.exp(x))),
-                                             np.log(dof_init), tol=tol, maxiter=50)
+        log_true_dof = scipy.optimize.newton(
+            lambda x: np.log(beta_shape_1_from_dof(r2_perm, np.exp(x))),
+            np.log(dof_init),
+            tol=tol,
+            maxiter=50,
+        )
         true_dof = np.exp(log_true_dof)
     except:
         # fall back to minimization
-        print('WARNING: scipy.optimize.newton failed to converge (running scipy.optimize.minimize)')
-        res = scipy.optimize.minimize(lambda x: np.abs(beta_shape_1_from_dof(r2_perm, x) - 1),
-                                      dof_init, method='Nelder-Mead', tol=tol)
+        print(
+            "WARNING: scipy.optimize.newton failed to converge (running scipy.optimize.minimize)"
+        )
+        res = scipy.optimize.minimize(
+            lambda x: np.abs(beta_shape_1_from_dof(r2_perm, x) - 1),
+            dof_init,
+            method="Nelder-Mead",
+            tol=tol,
+        )
         true_dof = res.x[0]
 
     pval = pval_from_corr(r2_perm, true_dof)
     mean, var = np.mean(pval), np.var(pval)
     beta_shape1 = mean * (mean * (1 - mean) / var - 1)
-    beta_shape2 = beta_shape1 * (1/mean - 1)
-    res = scipy.optimize.minimize(lambda s: beta_log_likelihood(pval, s[0], s[1]), [beta_shape1, beta_shape2], method='Nelder-Mead', tol=tol)
+    beta_shape2 = beta_shape1 * (1 / mean - 1)
+    res = scipy.optimize.minimize(
+        lambda s: beta_log_likelihood(pval, s[0], s[1]),
+        [beta_shape1, beta_shape2],
+        method="Nelder-Mead",
+        tol=tol,
+    )
     beta_shape1, beta_shape2 = res.x
     if return_minp:
         return beta_shape1, beta_shape2, true_dof, pval
@@ -388,42 +499,58 @@ def fit_beta_parameters(r2_perm, dof_init, tol=1e-4, return_minp=False):
         return beta_shape1, beta_shape2, true_dof
 
 
-def calculate_beta_approx_pval(r2_perm, r2_nominal, dof_init, tol=1e-4):
+def calculate_beta_approx_pval(
+    r2_perm: Any,
+    r2_nominal: Any,
+    dof_init: float | int,
+    tol: float = 1e-4,
+) -> tuple[Any, Any, Any, Any, Any]:
     """
-      r2_nominal: nominal max. r2 (scalar or array)
-      r2_perm:    array of max. r2 values from permutations
-      dof_init:   degrees of freedom
+    r2_nominal: nominal max. r2 (scalar or array)
+    r2_perm:    array of max. r2 values from permutations
+    dof_init:   degrees of freedom
     """
     beta_shape1, beta_shape2, true_dof = fit_beta_parameters(r2_perm, dof_init, tol)
     pval_true_dof = pval_from_corr(r2_nominal, true_dof)
     pval_beta = stats.beta.cdf(pval_true_dof, beta_shape1, beta_shape2)
     return pval_beta, beta_shape1, beta_shape2, true_dof, pval_true_dof
 
-#------------------------------------------------------------------------------
-#  i/o functions
-#------------------------------------------------------------------------------
 
-def read_phenotype_bed(phenotype_bed):
+# ------------------------------------------------------------------------------
+#  i/o functions
+# ------------------------------------------------------------------------------
+
+
+def read_phenotype_bed(
+    phenotype_bed: str,
+) -> tuple[pd.DataFrame, pd.DataFrame]:
     """Load phenotype BED file as phenotype and position DataFrames"""
-    if phenotype_bed.lower().endswith(('.bed.gz', '.bed')):
-        phenotype_df = pd.read_csv(phenotype_bed, sep='\t', index_col=3, dtype={'#chr':str, '#Chr':str})
-    elif phenotype_bed.lower().endswith('.bed.parquet'):
+    if phenotype_bed.lower().endswith((".bed.gz", ".bed")):
+        phenotype_df = pd.read_csv(
+            phenotype_bed, sep="\t", index_col=3, dtype={"#chr": str, "#Chr": str}
+        )
+    elif phenotype_bed.lower().endswith(".bed.parquet"):
         phenotype_df = pd.read_parquet(phenotype_bed)
         phenotype_df.set_index(phenotype_df.columns[3], inplace=True)
     else:
-        raise ValueError('Unsupported file type.')
-    phenotype_df.rename(columns={i:i.lower().replace('#chr','chr') for i in phenotype_df.columns[:3]}, inplace=True)
+        raise ValueError("Unsupported file type.")
+    phenotype_df.rename(
+        columns={i: i.lower().replace("#chr", "chr") for i in phenotype_df.columns[:3]},
+        inplace=True,
+    )
 
-    phenotype_df['start'] += 1  # change to 1-based
-    pos_df = phenotype_df[['chr', 'start', 'end']]
-    phenotype_df.drop(['chr', 'start', 'end'], axis=1, inplace=True)
+    phenotype_df["start"] += 1  # change to 1-based
+    pos_df = phenotype_df[["chr", "start", "end"]]
+    phenotype_df.drop(["chr", "start", "end"], axis=1, inplace=True)
 
     # make sure BED file is properly sorted
     assert pos_df.equals(
-        pos_df.groupby('chr', sort=False, group_keys=False)[pos_df.columns].apply(lambda x: x.sort_values(['start', 'end']))
+        pos_df.groupby("chr", sort=False, group_keys=False)[pos_df.columns].apply(
+            lambda x: x.sort_values(["start", "end"])
+        )
     ), "Positions in BED file must be sorted."
 
-    if (pos_df['start'] == pos_df['end']).all():
-        pos_df = pos_df[['chr', 'end']].rename(columns={'end':'pos'})
+    if (pos_df["start"] == pos_df["end"]).all():
+        pos_df = pos_df[["chr", "end"]].rename(columns={"end": "pos"})
 
     return phenotype_df, pos_df

--- a/tensorqtl/genotypeio.py
+++ b/tensorqtl/genotypeio.py
@@ -1,13 +1,18 @@
-import pandas as pd
-import tempfile
-import numpy as np
-import subprocess
-import os
-import gzip
-import sys
-import threading
-import queue
 import bisect
+import gzip
+import os
+import queue
+import subprocess
+import sys
+import tempfile
+import threading
+from collections.abc import Sequence
+from typing import Any, cast
+
+import numpy as np
+import numpy.typing as npt
+import pandas as pd
+from numpy.typing import DTypeLike
 from pandas_plink import read_plink
 
 sys.path.insert(1, os.path.dirname(__file__))
@@ -19,20 +24,34 @@ except ImportError as e:
     pgen = None
 
 
-gt_to_dosage_dict = {'0/0':0, '0/1':1, '1/1':2, './.':np.nan,
-                     '0|0':0, '0|1':1, '1|0':1, '1|1':2, '.|.':np.nan}
+gt_to_dosage_dict = {
+    "0/0": 0,
+    "0/1": 1,
+    "1/1": 2,
+    "./.": np.nan,
+    "0|0": 0,
+    "0|1": 1,
+    "1|0": 1,
+    "1|1": 2,
+    ".|.": np.nan,
+}
 
 
 def _check_dependency(name):
-    e = subprocess.call(f"which {name}", shell=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    e = subprocess.call(
+        f"which {name}",
+        shell=True,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
     if e != 0:
         raise RuntimeError(f"External dependency '{name}' not installed")
 
 
 def print_progress(k, n, entity):
-    s = f'\r    processing {entity} {k}/{n}'
+    s = f"\r    processing {entity} {k}/{n}"
     if k == n:
-        s += '\n'
+        s += "\n"
     sys.stdout.write(s)
     sys.stdout.flush()
 
@@ -70,21 +89,26 @@ class BackgroundGenerator(threading.Thread):
     def __iter__(self):
         return self
 
+
 class background:
     def __init__(self, max_prefetch=10):
         self.max_prefetch = max_prefetch
-    def __call__(self,gen):
-        def bg_generator(*args,**kwargs):
-            return BackgroundGenerator(gen(*args,**kwargs), max_prefetch=self.max_prefetch)
+
+    def __call__(self, gen):
+        def bg_generator(*args, **kwargs):
+            return BackgroundGenerator(
+                gen(*args, **kwargs), max_prefetch=self.max_prefetch
+            )
+
         return bg_generator
 
 
-#------------------------------------------------------------------------------
+# ------------------------------------------------------------------------------
 #  Functions for writing VCFs
-#------------------------------------------------------------------------------
+# ------------------------------------------------------------------------------
 def _get_vcf_opener(vcfpath):
-    if vcfpath.endswith('.vcf.gz'):
-        return gzip.open(vcfpath, 'rt')
+    if vcfpath.endswith(".vcf.gz"):
+        return gzip.open(vcfpath, "rt")
     else:
         return open(vcfpath)
 
@@ -93,46 +117,56 @@ def get_sample_ids(vcfpath):
     """Get sample IDs from VCF"""
     with _get_vcf_opener(vcfpath) as vcf:
         for header in vcf:
-            if header[:2] == '##': continue
+            if header[:2] == "##":
+                continue
             break
-    return header.strip().split('\t')[9:]
+    return header.strip().split("\t")[9:]
 
 
-def parse_genotypes(x, field='GT'):
+def parse_genotypes(x, field="GT"):
     """Convert list of genotypes (str) to np.float32"""
-    if field == 'GT':
+    if field == "GT":
         g = np.float32([gt_to_dosage_dict[i] for i in x])
-    elif field == 'DS':
+    elif field == "DS":
         g = np.float32(x)
     return g
 
 
 def _get_field_ix(line, field):
     """Get position of field ('GT' or 'DS') in FORMAT"""
-    fmt = line[8].split(':')
+    fmt = line[8].split(":")
     if field not in fmt:
-        raise ValueError(f'FORMAT field does not contain {field}')
+        raise ValueError(f"FORMAT field does not contain {field}")
     return fmt.index(field)
 
-#------------------------------------------------------------------------------
+
+# ------------------------------------------------------------------------------
 #  Functions for loading regions/variants from VCFs
-#------------------------------------------------------------------------------
+# ------------------------------------------------------------------------------
 def _impute_mean(g, missing=-9, verbose=False):
     """Impute rows to mean (in place)"""
     if not g.dtype in [np.float32, np.float64]:
-        raise ValueError('Input dtype must be np.float32 or np.float64')
+        raise ValueError("Input dtype must be np.float32 or np.float64")
     n = 0
     for i in np.where((g == missing).any(1))[0]:
         ix = g[i] == missing
         g[i][ix] = np.mean(g[i][~ix])
         n += 1
     if verbose and n > 0:
-        print(f'    imputed at least 1 sample in {n}/{g.shape[0]} sites')
+        print(f"    imputed at least 1 sample in {n}/{g.shape[0]} sites")
 
 
 class PlinkReader(object):
-    def __init__(self, plink_prefix_path, select_samples=None, include_variants=None,
-                 exclude_variants=None, exclude_chrs=None, verbose=True, dtype=np.int8):
+    def __init__(
+        self,
+        plink_prefix_path: str,
+        select_samples: Sequence[str] | None = None,
+        include_variants: Sequence[str] | None = None,
+        exclude_variants: Sequence[str] | None = None,
+        exclude_chrs: Sequence[str] | None = None,
+        verbose: bool = True,
+        dtype: DTypeLike = np.int8,
+    ) -> None:
         """
         Class for reading genotypes from PLINK bed files
 
@@ -156,50 +190,66 @@ class PlinkReader(object):
         if dtype == np.int8:
             self.bed[np.isnan(self.bed)] = -9  # convert missing (NaN) to -9 for int8
         self.bed = self.bed.astype(dtype, copy=False)
-        self.sample_ids = self.fam['iid'].tolist()
+        self.sample_ids: list[Any] = self.fam["iid"].tolist()
         if select_samples is not None:
             ix = [self.sample_ids.index(i) for i in select_samples]
             self.fam = self.fam.loc[ix]
-            self.bed = self.bed[:,ix]
-            self.sample_ids = self.fam['iid'].tolist()
+            self.bed = self.bed[:, ix]
+            self.sample_ids = self.fam["iid"].tolist()
         if include_variants is not None:
-            m = self.bim['snp'].isin(include_variants).values
-            self.bed = self.bed[m,:]
+            m: npt.NDArray[np.bool_] = (
+                self.bim["snp"].isin(include_variants).to_numpy(dtype=bool, copy=False)
+            )
+            self.bed = self.bed[m, :]
             self.bim = self.bim[m]
             self.bim.reset_index(drop=True, inplace=True)
-            self.bim['i'] = self.bim.index
+            self.bim["i"] = self.bim.index
         if exclude_variants is not None:
-            m = ~self.bim['snp'].isin(exclude_variants).values
-            self.bed = self.bed[m,:]
+            m = ~self.bim["snp"].isin(exclude_variants).to_numpy(dtype=bool, copy=False)
+            self.bed = self.bed[m, :]
             self.bim = self.bim[m]
             self.bim.reset_index(drop=True, inplace=True)
-            self.bim['i'] = self.bim.index
+            self.bim["i"] = self.bim.index
         if exclude_chrs is not None:
-            m = ~self.bim['chrom'].isin(exclude_chrs).values
-            self.bed = self.bed[m,:]
+            m = ~self.bim["chrom"].isin(exclude_chrs).to_numpy(dtype=bool, copy=False)
+            self.bed = self.bed[m, :]
             self.bim = self.bim[m]
             self.bim.reset_index(drop=True, inplace=True)
-            self.bim['i'] = self.bim.index
-        self.n_samples = self.fam.shape[0]
-        self.chrs = list(self.bim['chrom'].unique())
-        self.variant_pos = {i:g['pos'] for i,g in self.bim.set_index('snp')[['chrom', 'pos']].groupby('chrom')}
-        self.variant_pos_dict = self.bim.set_index('snp')['pos'].to_dict()
+            self.bim["i"] = self.bim.index
+        self.n_samples: int = int(self.fam.shape[0])
+        self.chrs: list[str] = [str(chrom) for chrom in self.bim["chrom"].unique()]
+        self.variant_pos: dict[str, pd.Series] = {
+            i: g["pos"]
+            for i, g in self.bim.set_index("snp")[["chrom", "pos"]].groupby("chrom")
+        }
+        self.variant_pos_dict: dict[str, Any] = self.bim.set_index("snp")[
+            "pos"
+        ].to_dict()
 
-    def get_region_index(self, region_str, return_pos=False):
-        s = region_str.split(':')
+    def get_region_index(
+        self, region_str: str, return_pos: bool = False
+    ) -> npt.NDArray[Any] | tuple[npt.NDArray[Any], pd.Series]:
+        s = region_str.split(":")
         chrom = s[0]
-        c = self.bim[self.bim['chrom'] == chrom]
+        c = self.bim[self.bim["chrom"] == chrom]
         if len(s) > 1:
-            start, end = s[1].split('-')
+            start, end = s[1].split("-")
             start = int(start)
             end = int(end)
-            c = c[(c['pos'] >= start) & (c['pos'] <= end)]
+            c = c[(c["pos"] >= start) & (c["pos"] <= end)]
         if return_pos:
-            return c['i'].values, c.set_index('snp')['pos']
+            return c["i"].values, c.set_index("snp")["pos"]
         else:
-            return c['i'].values
+            return c["i"].values
 
-    def get_region(self, region_str, sample_ids=None, impute=False, verbose=False, dtype=np.int8):
+    def get_region(
+        self,
+        region_str: str,
+        sample_ids: Sequence[str] | None = None,
+        impute: bool = False,
+        verbose: bool = False,
+        dtype: DTypeLike = np.int8,
+    ) -> tuple[npt.NDArray[Any], pd.Series]:
         """Get genotypes for a region defined by 'chr:start-end' or 'chr'"""
         ix, pos_s = self.get_region_index(region_str, return_pos=True)
         g = self.bed[ix, :].compute().astype(dtype)
@@ -210,69 +260,112 @@ class PlinkReader(object):
             _impute_mean(g, verbose=verbose)
         return g, pos_s
 
-    def get_genotypes(self, variant_ids, sample_ids=None, impute=False, verbose=False, dtype=np.int8):
+    def get_genotypes(
+        self,
+        variant_ids: Sequence[str],
+        sample_ids: Sequence[str] | None = None,
+        impute: bool = False,
+        verbose: bool = False,
+        dtype: DTypeLike = np.int8,
+    ) -> tuple[npt.NDArray[Any], pd.Series]:
         """Load genotypes for selected variant IDs"""
-        c = self.bim[self.bim['snp'].isin(variant_ids)]
+        c = self.bim[self.bim["snp"].isin(variant_ids)]
         g = self.bed[c.i.values, :].compute().astype(dtype)
         if sample_ids is not None:
             ix = [self.sample_ids.index(i) for i in sample_ids]
             g = g[:, ix]
         if impute:
             _impute_mean(g, verbose=verbose)
-        return g, c.set_index('snp')['pos']
+        return g, c.set_index("snp")["pos"]
 
-    def get_genotype(self, variant_id, sample_ids=None, impute=False, verbose=False, dtype=np.int8):
+    def get_genotype(
+        self,
+        variant_id: str,
+        sample_ids: Sequence[str] | None = None,
+        impute: bool = False,
+        verbose: bool = False,
+        dtype: DTypeLike = np.int8,
+    ) -> pd.Series:
         """Load genotypes for a single variant ID as pd.Series"""
-        g,_ = self.get_genotypes([variant_id], sample_ids=sample_ids, impute=impute, verbose=verbose, dtype=dtype)
+        g, _ = self.get_genotypes(
+            [variant_id],
+            sample_ids=sample_ids,
+            impute=impute,
+            verbose=verbose,
+            dtype=dtype,
+        )
         if sample_ids is None:
-            return pd.Series(g[0], index=self.fam['iid'], name=variant_id)
+            return pd.Series(g[0], index=self.fam["iid"], name=variant_id)
         else:
             return pd.Series(g[0], index=sample_ids, name=variant_id)
 
-    def load_genotypes(self):
+    def load_genotypes(self) -> pd.DataFrame:
         """Load all genotypes into memory, as pd.DataFrame"""
-        return pd.DataFrame(self.bed.compute(), index=self.bim['snp'], columns=self.fam['iid'])
+        return pd.DataFrame(
+            self.bed.compute(), index=self.bim["snp"], columns=self.fam["iid"]
+        )
 
 
-def load_genotypes(genotype_path, select_samples=None, dosages=False):
+def load_genotypes(
+    genotype_path: str,
+    select_samples: Sequence[str] | None = None,
+    dosages: bool = False,
+):
     """Load all genotypes into a dataframe"""
-    if all([os.path.exists(f"{genotype_path}.{ext}") for ext in ['pgen', 'psam', 'pvar']]):
+    if all(
+        [os.path.exists(f"{genotype_path}.{ext}") for ext in ["pgen", "psam", "pvar"]]
+    ):
         if pgen is None:
-            raise ImportError('Pgenlib must be installed to use PLINK 2 pgen/psam/pvar files.')
+            raise ImportError(
+                "Pgenlib must be installed to use PLINK 2 pgen/psam/pvar files."
+            )
         pgr = pgen.PgenReader(genotype_path, select_samples=select_samples)
-        variant_df = pgr.pvar_df.set_index('id')[['chrom', 'pos']]
+        variant_df = pgr.pvar_df.set_index("id")[["chrom", "pos"]]
         if dosages:
             genotype_df = pgr.load_dosages()
         else:
             genotype_df = pgr.load_genotypes()
-    elif all([os.path.exists(f"{genotype_path}.{ext}") for ext in ['bed', 'bim', 'fam']]):
+    elif all(
+        [os.path.exists(f"{genotype_path}.{ext}") for ext in ["bed", "bim", "fam"]]
+    ):
         pr = PlinkReader(genotype_path, select_samples=select_samples, dtype=np.int8)
         genotype_df = pr.load_genotypes()
-        variant_df = pr.bim.set_index('snp')[['chrom', 'pos']]
-    elif genotype_path.endswith(('.bed.parquet', '.bed.gz', '.bed')):
+        variant_df = pr.bim.set_index("snp")[["chrom", "pos"]]
+    elif genotype_path.endswith((".bed.parquet", ".bed.gz", ".bed")):
         genotype_df, variant_df = read_phenotype_bed(genotype_path)
-        assert variant_df.columns[1] == 'pos', "The BED file must define a single position for each variant, with start + 1 == end."
-        variant_df.columns = ['chrom', 'pos']
-    elif genotype_path.endswith('.parquet'):
+        assert variant_df.columns[1] == "pos", (
+            "The BED file must define a single position for each variant, with start + 1 == end."
+        )
+        variant_df.columns = ["chrom", "pos"]
+    elif genotype_path.endswith(".parquet"):
         genotype_df = pd.read_parquet(genotype_path)
         variant_df = None
-    elif genotype_path.endswith('.gz'):
-        with gzip.open(genotype_path, 'rt') as f:
-            header = f.readline().strip().split('\t')
-        dtypes = {i:np.float32 for i in header}
+    elif genotype_path.endswith(".gz"):
+        with gzip.open(genotype_path, "rt") as f:
+            header = f.readline().strip().split("\t")
+        dtypes = {i: np.float32 for i in header}
         dtypes[header[0]] = str
-        genotype_df = pd.read_csv(genotype_path, sep='\t', index_col=0, dtype=dtypes)
+        genotype_df = pd.read_csv(genotype_path, sep="\t", index_col=0, dtype=dtypes)
         variant_df = None
     else:
-        raise ValueError(f"Failed to load genotypes from {genotype_path}. Supported formats: pgen/psam/pvar, bed/bim/fam, parquet, tsv.gz")
+        raise ValueError(
+            f"Failed to load genotypes from {genotype_path}. Supported formats: pgen/psam/pvar, bed/bim/fam, parquet, tsv.gz"
+        )
     return genotype_df, variant_df
 
 
-def get_vcf_region(region_str, vcfpath, field='GT', sample_ids=None, select_samples=None, impute_missing=True):
+def get_vcf_region(
+    region_str,
+    vcfpath,
+    field="GT",
+    sample_ids=None,
+    select_samples=None,
+    impute_missing=True,
+):
     """Load VCF region (str: 'chr:start-end') as DataFrame (requires tabix)"""
-    s = subprocess.check_output(f'tabix {vcfpath} {region_str}', shell=True)
-    s = s.decode().strip().split('\n')
-    s = [i.split('\t') for i in s]
+    s = subprocess.check_output(f"tabix {vcfpath} {region_str}", shell=True)
+    s = s.decode().strip().split("\n")
+    s = [i.split("\t") for i in s]
 
     if sample_ids is None:
         sample_ids = get_sample_ids(vcfpath)
@@ -280,7 +373,12 @@ def get_vcf_region(region_str, vcfpath, field='GT', sample_ids=None, select_samp
     pos_s = pd.Series([int(i[1]) for i in s], index=variant_ids)
 
     ix = _get_field_ix(s[0], field)
-    g = np.array([parse_genotypes([i.split(':')[ix] for i in line[9:]], field=field) for line in s])
+    g = np.array(
+        [
+            parse_genotypes([i.split(":")[ix] for i in line[9:]], field=field)
+            for line in s
+        ]
+    )
     df = pd.DataFrame(g, index=variant_ids, columns=sample_ids)
 
     if select_samples is not None:
@@ -294,39 +392,53 @@ def get_vcf_region(region_str, vcfpath, field='GT', sample_ids=None, select_samp
                 v[m] = np.mean(v[~m])
                 n += 1
         if n > 0:
-            print(f'    imputed at least 1 sample in {n} sites')
+            print(f"    imputed at least 1 sample in {n} sites")
 
     return df, pos_s
 
 
-def get_vcf_variants(variant_ids, vcfpath, field='GT', sample_ids=None):
+def get_vcf_variants(variant_ids, vcfpath, field="GT", sample_ids=None):
     """Load a set of variants in VCF as DataFrame (requires tabix)"""
     variant_id_set = set(variant_ids)
     with tempfile.NamedTemporaryFile() as regions_file:
-        df = pd.DataFrame([i.split('_')[:2] for i in variant_id_set], columns=['chr', 'pos'])
-        df['pos'] = df['pos'].astype(int)
-        df = df.sort_values(['chr', 'pos'])
-        df.to_csv(regions_file.name, sep='\t', index=False, header=False)
-        s = subprocess.check_output(f'tabix {vcfpath} --regions {regions_file.name}', shell=True)
-    s = s.decode().strip().split('\n')
-    s = [i.split('\t') for i in s]
+        df = pd.DataFrame(
+            [i.split("_")[:2] for i in variant_id_set], columns=["chr", "pos"]
+        )
+        df["pos"] = df["pos"].astype(int)
+        df = df.sort_values(["chr", "pos"])
+        df.to_csv(regions_file.name, sep="\t", index=False, header=False)
+        s = subprocess.check_output(
+            f"tabix {vcfpath} --regions {regions_file.name}", shell=True
+        )
+    s = s.decode().strip().split("\n")
+    s = [i.split("\t") for i in s]
 
     if sample_ids is None:
         sample_ids = get_sample_ids(vcfpath)
 
     ix = _get_field_ix(s[0], field)
-    g = np.array([parse_genotypes([i.split(':')[ix] for i in line[9:]], field=field) for line in s])
-    g = np.array([i for i in g if -1 not in i])  # filter missing here instead of ValueError?
+    g = np.array(
+        [
+            parse_genotypes([i.split(":")[ix] for i in line[9:]], field=field)
+            for line in s
+        ]
+    )
+    g = np.array(
+        [i for i in g if -1 not in i]
+    )  # filter missing here instead of ValueError?
 
     returned_variant_ids = [i[2] for i in s]
-    ix = [k for k,i in enumerate(returned_variant_ids) if i in variant_id_set]
+    ix = [k for k, i in enumerate(returned_variant_ids) if i in variant_id_set]
     g = np.array([g[i] for i in ix])
     returned_variant_ids = [returned_variant_ids[i] for i in ix]
-    return pd.DataFrame(g.astype(np.float32), index=returned_variant_ids, columns=sample_ids)
+    return pd.DataFrame(
+        g.astype(np.float32), index=returned_variant_ids, columns=sample_ids
+    )
 
-#------------------------------------------------------------------------------
+
+# ------------------------------------------------------------------------------
 #  Generator classes for batch processing of genotypes/phenotypes
-#------------------------------------------------------------------------------
+# ------------------------------------------------------------------------------
 class GenotypeGeneratorTrans(object):
     def __init__(self, genotype_df, batch_size=50000, chr_s=None):
         """
@@ -341,7 +453,9 @@ class GenotypeGeneratorTrans(object):
         self.genotype_df = genotype_df
         self.batch_size = batch_size
         self.num_batches = int(np.ceil(self.genotype_df.shape[0] / batch_size))
-        self.batch_indexes = [[i*batch_size, (i+1)*batch_size] for i in range(self.num_batches)]
+        self.batch_indexes = [
+            [i * batch_size, (i + 1) * batch_size] for i in range(self.num_batches)
+        ]
         self.batch_indexes[-1][1] = self.genotype_df.shape[0]
         if chr_s is not None:
             chroms, chr_ix = np.unique(chr_s, return_index=True)
@@ -350,10 +464,13 @@ class GenotypeGeneratorTrans(object):
             chr_ix = list(chr_ix[s]) + [chr_s.shape[0]]
             size_s = pd.Series(np.diff(chr_ix), index=self.chroms)
             self.chr_batch_indexes = {}
-            for k,c in enumerate(self.chroms):
+            for k, c in enumerate(self.chroms):
                 num_batches = int(np.ceil(size_s[c] / batch_size))
-                batch_indexes = [[chr_ix[k]+i*batch_size, chr_ix[k]+(i+1)*batch_size] for i in range(num_batches)]
-                batch_indexes[-1][1] = chr_ix[k+1]
+                batch_indexes = [
+                    [chr_ix[k] + i * batch_size, chr_ix[k] + (i + 1) * batch_size]
+                    for i in range(num_batches)
+                ]
+                batch_indexes[-1][1] = chr_ix[k + 1]
                 self.chr_batch_indexes[c] = batch_indexes
 
     def __len__(self):
@@ -369,11 +486,11 @@ class GenotypeGeneratorTrans(object):
             batch_indexes = self.chr_batch_indexes[chrom]
             num_batches = np.sum([len(i) for i in self.chr_batch_indexes.values()])
 
-        for k,i in enumerate(batch_indexes, enum_start):  # loop through batches
+        for k, i in enumerate(batch_indexes, enum_start):  # loop through batches
             if verbose:
-                print_progress(k, num_batches, 'batch')
-            g = self.genotype_df.values[i[0]:i[1]]
-            ix = self.genotype_df.index[i[0]:i[1]]  # variant IDs
+                print_progress(k, num_batches, "batch")
+            g = self.genotype_df.values[i[0] : i[1]]
+            ix = self.genotype_df.index[i[0] : i[1]]  # variant IDs
             yield g, ix
 
 
@@ -384,25 +501,29 @@ def get_cis_ranges(phenotype_pos_df, chr_variant_dfs, window, verbose=True):
     """
     # check phenotypes & calculate genotype ranges
     # get genotype indexes corresponding to cis-window of each phenotype
-    if 'pos' in phenotype_pos_df:
-        phenotype_pos_df = phenotype_pos_df.rename(columns={'pos':'start'})
-        phenotype_pos_df['end'] = phenotype_pos_df['start']
-    phenotype_pos_dict = phenotype_pos_df.to_dict(orient='index')
+    if "pos" in phenotype_pos_df:
+        phenotype_pos_df = phenotype_pos_df.rename(columns={"pos": "start"})
+        phenotype_pos_df["end"] = phenotype_pos_df["start"]
+    phenotype_pos_dict = phenotype_pos_df.to_dict(orient="index")
 
     drop_ids = []
     cis_ranges = {}
     n = len(phenotype_pos_df)
     for k, phenotype_id in enumerate(phenotype_pos_df.index, 1):
         if verbose and (k % 1000 == 0 or k == n):
-            print(f'\r  * checking phenotypes: {k}/{n}',  end='' if k != n else None)
+            print(f"\r  * checking phenotypes: {k}/{n}", end="" if k != n else None)
 
         pos = phenotype_pos_dict[phenotype_id]
-        chrom = pos['chr']
-        m = len(chr_variant_dfs[chrom]['pos'].values)
-        lb = bisect.bisect_left(chr_variant_dfs[chrom]['pos'].values, pos['start'] - window)
-        ub = bisect.bisect_right(chr_variant_dfs[chrom]['pos'].values, pos['end'] + window)
+        chrom = pos["chr"]
+        m = len(chr_variant_dfs[chrom]["pos"].values)
+        lb = bisect.bisect_left(
+            chr_variant_dfs[chrom]["pos"].values, pos["start"] - window
+        )
+        ub = bisect.bisect_right(
+            chr_variant_dfs[chrom]["pos"].values, pos["end"] + window
+        )
         if lb != ub:
-            r = chr_variant_dfs[chrom]['index'].values[[lb, ub - 1]]
+            r = chr_variant_dfs[chrom]["index"].values[[lb, ub - 1]]
         else:
             r = []
 
@@ -428,28 +549,37 @@ class InputGeneratorCis(object):
 
     Generates: phenotype array, genotype array (2D), cis-window indices, phenotype ID
     """
-    def __init__(self, genotype_df, variant_df, phenotype_df, phenotype_pos_df, group_s=None, window=1000000):
+
+    def __init__(
+        self,
+        genotype_df,
+        variant_df,
+        phenotype_df,
+        phenotype_pos_df,
+        group_s=None,
+        window=1000000,
+    ):
         assert (genotype_df.index == variant_df.index).all()
         assert (phenotype_df.index == phenotype_df.index.unique()).all()
         self.genotype_df = genotype_df
         self.variant_df = variant_df.copy()
-        self.variant_df['index'] = np.arange(variant_df.shape[0])
+        self.variant_df["index"] = np.arange(variant_df.shape[0])
         self.n_samples = phenotype_df.shape[1]
 
         # drop phenotypes without genotypes on same contig
-        variant_chrs = variant_df['chrom'].unique()
-        phenotype_chrs = phenotype_pos_df['chr'].unique()
+        variant_chrs = variant_df["chrom"].unique()
+        phenotype_chrs = phenotype_pos_df["chr"].unique()
         self.chrs = [i for i in phenotype_chrs if i in variant_chrs]
-        m = phenotype_pos_df['chr'].isin(self.chrs)
+        m = phenotype_pos_df["chr"].isin(self.chrs)
         if any(~m):
-            print(f'    ** dropping {sum(~m)} phenotypes on chrs. without genotypes')
+            print(f"    ** dropping {sum(~m)} phenotypes on chrs. without genotypes")
         self.phenotype_df = phenotype_df[m]
         self.phenotype_pos_df = phenotype_pos_df[m]
 
         # check for constant phenotypes and drop
-        m = np.all(self.phenotype_df.values == self.phenotype_df.values[:,[0]], 1)
+        m = np.all(self.phenotype_df.values == self.phenotype_df.values[:, [0]], 1)
         if m.any():
-            print(f'    ** dropping {np.sum(m)} constant phenotypes')
+            print(f"    ** dropping {np.sum(m)} constant phenotypes")
             self.phenotype_df = self.phenotype_df.loc[~m]
             self.phenotype_pos_df = self.phenotype_pos_df.loc[~m]
 
@@ -459,27 +589,32 @@ class InputGeneratorCis(object):
         self.group_s = None
         self.window = window
 
-        self.chr_variant_dfs = {c:g[['pos', 'index']] for c,g in self.variant_df.groupby('chrom')}
+        self.chr_variant_dfs = {
+            c: g[["pos", "index"]] for c, g in self.variant_df.groupby("chrom")
+        }
 
         # check phenotypes & calculate genotype ranges
         # get genotype indexes corresponding to cis-window of each phenotype
-        self.cis_ranges, drop_ids = get_cis_ranges(self.phenotype_pos_df, self.chr_variant_dfs, self.window)
+        self.cis_ranges, drop_ids = get_cis_ranges(
+            self.phenotype_pos_df, self.chr_variant_dfs, self.window
+        )
         if len(drop_ids) > 0:
-            print(f"    ** dropping {len(drop_ids)} phenotypes without variants in cis-window")
+            print(
+                f"    ** dropping {len(drop_ids)} phenotypes without variants in cis-window"
+            )
             self.phenotype_df = self.phenotype_df.drop(drop_ids)
             self.phenotype_pos_df = self.phenotype_pos_df.drop(drop_ids)
-        if 'pos' in self.phenotype_pos_df:
-            self.phenotype_start = self.phenotype_pos_df['pos'].to_dict()
+        if "pos" in self.phenotype_pos_df:
+            self.phenotype_start = self.phenotype_pos_df["pos"].to_dict()
             self.phenotype_end = self.phenotype_start
         else:
-            self.phenotype_start = self.phenotype_pos_df['start'].to_dict()
-            self.phenotype_end = self.phenotype_pos_df['end'].to_dict()
+            self.phenotype_start = self.phenotype_pos_df["start"].to_dict()
+            self.phenotype_end = self.phenotype_pos_df["end"].to_dict()
         self.n_phenotypes = self.phenotype_df.shape[0]
 
         if group_s is not None:
             self.group_s = group_s.loc[self.phenotype_df.index].copy()
             self.n_groups = self.group_s.unique().shape[0]
-
 
     @background(max_prefetch=6)
     def generate_data(self, chrom=None, verbose=False):
@@ -492,35 +627,71 @@ class InputGeneratorCis(object):
             phenotype_ids = self.phenotype_df.index
             chr_offset = 0
         else:
-            phenotype_ids = self.phenotype_pos_df[self.phenotype_pos_df['chr'] == chrom].index
+            phenotype_ids = self.phenotype_pos_df[
+                self.phenotype_pos_df["chr"] == chrom
+            ].index
             if self.group_s is None:
-                offset_dict = {i:j for i,j in zip(*np.unique(self.phenotype_pos_df['chr'], return_index=True))}
+                offset_dict = {
+                    i: j
+                    for i, j in zip(
+                        *np.unique(self.phenotype_pos_df["chr"], return_index=True)
+                    )
+                }
             else:
-                offset_dict = {i:j for i,j in zip(*np.unique(self.phenotype_pos_df['chr'][self.group_s.drop_duplicates().index], return_index=True))}
+                offset_dict = {
+                    i: j
+                    for i, j in zip(
+                        *np.unique(
+                            self.phenotype_pos_df["chr"][
+                                self.group_s.drop_duplicates().index
+                            ],
+                            return_index=True,
+                        )
+                    )
+                }
             chr_offset = offset_dict[chrom]
 
-        index_dict = {j:i for i,j in enumerate(self.phenotype_df.index)}
+        index_dict = {j: i for i, j in enumerate(self.phenotype_df.index)}
 
         if self.group_s is None:
-            for k,phenotype_id in enumerate(phenotype_ids, chr_offset+1):
+            for k, phenotype_id in enumerate(phenotype_ids, chr_offset + 1):
                 if verbose:
-                    print_progress(k, self.n_phenotypes, 'phenotype')
+                    print_progress(k, self.n_phenotypes, "phenotype")
                 p = self.phenotype_df.values[index_dict[phenotype_id]]
                 # p = self.phenotype_df.values[k]
                 r = self.cis_ranges[phenotype_id]
-                yield p, self.genotype_df.values[r[0]:r[-1]+1], np.arange(r[0],r[-1]+1), phenotype_id
+                yield (
+                    p,
+                    self.genotype_df.values[r[0] : r[-1] + 1],
+                    np.arange(r[0], r[-1] + 1),
+                    phenotype_id,
+                )
         else:
             gdf = self.group_s[phenotype_ids].groupby(self.group_s, sort=False)
-            for k,(group_id,g) in enumerate(gdf, chr_offset+1):
+            for k, (group_id, g) in enumerate(gdf, chr_offset + 1):
                 if verbose:
-                    print_progress(k, self.n_groups, 'phenotype group')
+                    print_progress(k, self.n_groups, "phenotype group")
                 # check that ranges are the same for all phenotypes within group
-                assert np.all([self.cis_ranges[g.index[0]][0] == self.cis_ranges[i][0] and self.cis_ranges[g.index[0]][1] == self.cis_ranges[i][1] for i in g.index[1:]])
+                assert np.all(
+                    [
+                        self.cis_ranges[g.index[0]][0] == self.cis_ranges[i][0]
+                        and self.cis_ranges[g.index[0]][1] == self.cis_ranges[i][1]
+                        for i in g.index[1:]
+                    ]
+                )
                 group_phenotype_ids = g.index.tolist()
                 # p = self.phenotype_df.loc[group_phenotype_ids].values
-                p = self.phenotype_df.values[[index_dict[i] for i in group_phenotype_ids]]
+                p = self.phenotype_df.values[
+                    [index_dict[i] for i in group_phenotype_ids]
+                ]
                 r = self.cis_ranges[g.index[0]]
-                yield p, self.genotype_df.values[r[0]:r[-1]+1], np.arange(r[0],r[-1]+1), group_phenotype_ids, group_id
+                yield (
+                    p,
+                    self.genotype_df.values[r[0] : r[-1] + 1],
+                    np.arange(r[0], r[-1] + 1),
+                    group_phenotype_ids,
+                    group_id,
+                )
 
 
 def get_chunk_size(memory_gb, samples):
@@ -528,8 +699,15 @@ def get_chunk_size(memory_gb, samples):
     return memory_gb * 1024**3 // samples
 
 
-def generate_paired_chunks(pgr, phenotype_df, phenotype_pos_df, chunk_size, window=1000000,
-                           dosages=False, verbose=True):
+def generate_paired_chunks(
+    pgr,
+    phenotype_df,
+    phenotype_pos_df,
+    chunk_size,
+    window=1000000,
+    dosages=False,
+    verbose=True,
+):
     """
     Generate paired genotype-phenotype chunks for large datasets where only a subset of
     genotypes can be loaded into memory.
@@ -541,38 +719,54 @@ def generate_paired_chunks(pgr, phenotype_df, phenotype_pos_df, chunk_size, wind
     window: cis-window
     dosages: load dosages (DS) from genotype files (default: GT)
     """
-    variant_df = pgr.pvar_df.set_index('id')[['chrom', 'pos']]
+    variant_df = pgr.pvar_df.set_index("id")[["chrom", "pos"]]
     cis_ranges, _ = get_cis_ranges(phenotype_pos_df, pgr.variant_dfs, window)
-    range_df = pd.DataFrame(cis_ranges, index=['start', 'end']).T
-    range_df = range_df.join(phenotype_pos_df['chr'])
+    range_df = pd.DataFrame(cis_ranges, index=["start", "end"]).T
+    range_df = range_df.join(phenotype_pos_df["chr"])
 
-    if chunk_size == 'chr':
-        chrlen_s = range_df['chr'].value_counts(sort=False)
+    if chunk_size == "chr":
+        chrlen_s = range_df["chr"].value_counts(sort=False)
         start_ixs = [0] + chrlen_s.cumsum().tolist()
     else:
         chunk_size = int(chunk_size)
         # check chunk size
-        max_cis_var = (range_df['end'] - range_df['start'] + 1).max()
+        max_cis_var = (range_df["end"] - range_df["start"] + 1).max()
         if not max_cis_var <= chunk_size:
-            raise ValueError(f"Max. chunk size must be at least largest cis-window ({max_cis_var})")
+            raise ValueError(
+                f"Max. chunk size must be at least largest cis-window ({max_cis_var})"
+            )
 
         start_ixs = [0]
         while start_ixs[-1] < range_df.shape[0]:
-            end_ix = bisect.bisect_left(range_df['end'].values, range_df['start'].values[start_ixs[-1]] + chunk_size)
+            end_ix = bisect.bisect_left(
+                range_df["end"].values,
+                range_df["start"].values[start_ixs[-1]] + chunk_size,
+            )
             start_ixs.append(end_ix)
         start_ixs[-1] = range_df.shape[0]
 
     nchunks = len(start_ixs) - 1
     for ci in range(nchunks):
         if verbose:
-            print(f"Processing genotype-phenotype chunk {ci+1}/{nchunks}")
-        ix = slice(start_ixs[ci], start_ixs[ci+1])
+            print(f"Processing genotype-phenotype chunk {ci + 1}/{nchunks}")
+        ix = slice(start_ixs[ci], start_ixs[ci + 1])
         chunk_df = range_df[ix]
-        if chunk_size == 'chr':
-            assert (chunk_df['chr'] == chrlen_s.index[ci]).all()
+        if chunk_size == "chr":
+            assert (chunk_df["chr"] == chrlen_s.index[ci]).all()
         if dosages:
-            gt_df = pgr.read_dosages_range(chunk_df['start'].values[0], chunk_df['end'].values[-1], dtype=np.float32)
+            gt_df = pgr.read_dosages_range(
+                chunk_df["start"].values[0],
+                chunk_df["end"].values[-1],
+                dtype=np.float32,
+            )
         else:
-            gt_df = pgr.read_range(chunk_df['start'].values[0], chunk_df['end'].values[-1], impute_mean=False, dtype=np.int8)
-        var_df = variant_df.iloc[chunk_df['start'].values[0]:chunk_df['end'].values[-1]+1]
+            gt_df = pgr.read_range(
+                chunk_df["start"].values[0],
+                chunk_df["end"].values[-1],
+                impute_mean=False,
+                dtype=np.int8,
+            )
+        var_df = variant_df.iloc[
+            chunk_df["start"].values[0] : chunk_df["end"].values[-1] + 1
+        ]
         yield gt_df, var_df, phenotype_df[ix], phenotype_pos_df[ix], ci

--- a/tensorqtl/pgen.py
+++ b/tensorqtl/pgen.py
@@ -1,24 +1,41 @@
 # Functions for reading dosages from PLINK pgen files based on the Pgenlib Python API:
 # https://github.com/chrchang/plink-ng/blob/master/2.0/Python/python_api.txt
 
+import bisect
+import os
+from collections.abc import Sequence
+from typing import Any
+
 import numpy as np
+import numpy.typing as npt
 import pandas as pd
 import pgenlib as pg
-import os
-import bisect
+from numpy.typing import DTypeLike
 
 
 def read_pvar(pvar_path):
     """Read pvar file as pd.DataFrame"""
-    return pd.read_csv(pvar_path, sep='\t', comment='#',
-                       names=['chrom', 'pos', 'id', 'ref', 'alt', 'qual', 'filter', 'info'],
-                       dtype={'chrom':str, 'pos':np.int32, 'id':str, 'ref':str, 'alt':str,
-                              'qual':str, 'filter':str, 'info':str})
+    return pd.read_csv(
+        pvar_path,
+        sep="\t",
+        comment="#",
+        names=["chrom", "pos", "id", "ref", "alt", "qual", "filter", "info"],
+        dtype={
+            "chrom": str,
+            "pos": np.int32,
+            "id": str,
+            "ref": str,
+            "alt": str,
+            "qual": str,
+            "filter": str,
+            "info": str,
+        },
+    )
 
 
 def read_psam(psam_path):
     """Read psam file as pd.DataFrame"""
-    psam_df = pd.read_csv(psam_path, sep='\t', index_col=0)
+    psam_df = pd.read_csv(psam_path, sep="\t", index_col=0)
     psam_df.index = psam_df.index.astype(str)
     return psam_df
 
@@ -29,15 +46,16 @@ def hardcall_phase_present(pgen_path):
         return r.hardcall_phase_present()
 
 
-def get_reader(pgen_path, sample_subset=None):
+def get_reader(pgen_path: str, sample_subset: Sequence[int] | None = None):
     """"""
+    sample_subset_array = None
     if sample_subset is not None:
-        sample_subset = np.array(sample_subset, dtype=np.uint32)
-    reader = pg.PgenReader(pgen_path.encode(), sample_subset=sample_subset)
-    if sample_subset is None:
+        sample_subset_array = np.asarray(sample_subset, dtype=np.uint32)
+    reader = pg.PgenReader(pgen_path.encode(), sample_subset=sample_subset_array)
+    if sample_subset_array is None:
         num_samples = reader.get_raw_sample_ct()
     else:
-        num_samples = len(sample_subset)
+        num_samples = len(sample_subset_array)
     return reader, num_samples
 
 
@@ -68,7 +86,12 @@ def read(pgen_path, variant_idx, sample_subset=None, dtype=np.int8):
     return genotypes
 
 
-def read_dosages(pgen_path, variant_idx, sample_subset=None, dtype=np.float32):
+def read_dosages(
+    pgen_path: str,
+    variant_idx: int,
+    sample_subset: Sequence[int] | None = None,
+    dtype: DTypeLike = np.float32,
+):
     """
     Get dosages for a variant.
 
@@ -117,13 +140,18 @@ def read_alleles(pgen_path, variant_idx, sample_subset=None):
         If the genotype is unphased, the lower index appears first.
     """
     reader, num_samples = get_reader(pgen_path, sample_subset=sample_subset)
-    alleles = np.zeros(2*num_samples, dtype=np.int32)
+    alleles = np.zeros(2 * num_samples, dtype=np.int32)
     with reader as r:
         r.read_alleles(np.array(variant_idx, dtype=np.uint32), alleles)
     return alleles
 
 
-def read_list(pgen_path, variant_idxs, sample_subset=None, dtype=np.int8):
+def read_list(
+    pgen_path: str,
+    variant_idxs: Sequence[int],
+    sample_subset: Sequence[int] | None = None,
+    dtype: DTypeLike = np.int8,
+):
     """
     Get genotypes for a list of variants.
 
@@ -151,7 +179,12 @@ def read_list(pgen_path, variant_idxs, sample_subset=None, dtype=np.int8):
     return genotypes
 
 
-def read_dosages_list(pgen_path, variant_idxs, sample_subset=None, dtype=np.float32):
+def read_dosages_list(
+    pgen_path: str,
+    variant_idxs: Sequence[int],
+    sample_subset: Sequence[int] | None = None,
+    dtype: DTypeLike = np.float32,
+):
     """
     Get dosages for a list of variants.
 
@@ -199,13 +232,19 @@ def read_alleles_list(pgen_path, variant_idxs, sample_subset=None):
     """
     reader, num_samples = get_reader(pgen_path, sample_subset=sample_subset)
     num_variants = len(variant_idxs)
-    alleles = np.zeros([num_variants, 2*num_samples], dtype=np.int32)
+    alleles = np.zeros([num_variants, 2 * num_samples], dtype=np.int32)
     with reader as r:
         r.read_alleles_list(np.array(variant_idxs, dtype=np.uint32), alleles)
     return alleles
 
 
-def read_range(pgen_path, start_idx, end_idx, sample_subset=None, dtype=np.int8):
+def read_range(
+    pgen_path: str,
+    start_idx: int,
+    end_idx: int,
+    sample_subset: Sequence[int] | None = None,
+    dtype: DTypeLike = np.int8,
+):
     """
     Get genotypes for a range of variants.
 
@@ -231,11 +270,17 @@ def read_range(pgen_path, start_idx, end_idx, sample_subset=None, dtype=np.int8)
     num_variants = end_idx - start_idx + 1
     genotypes = np.zeros([num_variants, num_samples], dtype=dtype)
     with reader as r:
-        r.read_range(start_idx, end_idx+1, genotypes)
+        r.read_range(start_idx, end_idx + 1, genotypes)
     return genotypes
 
 
-def read_dosages_range(pgen_path, start_idx, end_idx, sample_subset=None, dtype=np.float32):
+def read_dosages_range(
+    pgen_path: str,
+    start_idx: int,
+    end_idx: int,
+    sample_subset: Sequence[int] | None = None,
+    dtype: DTypeLike = np.float32,
+):
     """
     Get dosages for a range of variants.
 
@@ -261,7 +306,7 @@ def read_dosages_range(pgen_path, start_idx, end_idx, sample_subset=None, dtype=
     num_variants = end_idx - start_idx + 1
     dosages = np.zeros([num_variants, num_samples], dtype=dtype)
     with reader as r:
-        r.read_dosages_range(start_idx, end_idx+1, dosages)
+        r.read_dosages_range(start_idx, end_idx + 1, dosages)
     return dosages
 
 
@@ -287,9 +332,9 @@ def read_alleles_range(pgen_path, start_idx, end_idx, sample_subset=None):
     """
     reader, num_samples = get_reader(pgen_path, sample_subset=sample_subset)
     num_variants = end_idx - start_idx + 1
-    alleles = np.zeros([num_variants, 2*num_samples], dtype=np.int32)
+    alleles = np.zeros([num_variants, 2 * num_samples], dtype=np.int32)
     with reader as r:
-        r.read_alleles_range(start_idx, end_idx+1, alleles)
+        r.read_alleles_range(start_idx, end_idx + 1, alleles)
     return alleles
 
 
@@ -303,7 +348,7 @@ def _impute_mean(genotypes):
         if len(ix) > 0:
             a = genotypes.sum(1)
             b = m.sum(1)
-            mu = (a + 9*b) / (genotypes.shape[1] - b)
+            mu = (a + 9 * b) / (genotypes.shape[1] - b)
             genotypes[m] = mu[ix]
 
 
@@ -318,7 +363,10 @@ class PgenReader(object):
 
     Requires pgenlib: https://github.com/chrchang/plink-ng/tree/master/2.0/Python
     """
-    def __init__(self, plink_prefix_path, select_samples=None):
+
+    def __init__(
+        self, plink_prefix_path: str, select_samples: Sequence[str] | None = None
+    ):
         """
         plink_prefix_path: prefix to PLINK pgen,psam,pvar files
         select_samples: specify a subset of samples
@@ -332,18 +380,20 @@ class PgenReader(object):
         self.pgen_file = f"{plink_prefix_path}.pgen"
 
         self.num_variants = self.pvar_df.shape[0]
-        self.variant_ids = self.pvar_df['id'].tolist()
-        self.variant_idx_dict = {i:k for k,i in enumerate(self.variant_ids)}
+        self.variant_ids = self.pvar_df["id"].tolist()
+        self.variant_idx_dict = {i: k for k, i in enumerate(self.variant_ids)}
 
-        self.sample_id_list = self.psam_df.index.tolist()
+        self.sample_id_list: list[Any] = self.psam_df.index.tolist()
         self.set_samples(select_samples)
 
-        variant_df = self.pvar_df.set_index('id')[['chrom', 'pos']]
-        variant_df['index'] = np.arange(variant_df.shape[0])
+        variant_df = self.pvar_df.set_index("id")[["chrom", "pos"]]
+        variant_df["index"] = np.arange(variant_df.shape[0])
         self.variant_df = variant_df
-        self.variant_dfs = {c:g[['pos', 'index']] for c,g in variant_df.groupby('chrom', sort=False)}
+        self.variant_dfs = {
+            c: g[["pos", "index"]] for c, g in variant_df.groupby("chrom", sort=False)
+        }
 
-    def set_samples(self, sample_ids=None, sort=True):
+    def set_samples(self, sample_ids: Sequence[Any] | None = None, sort: bool = True):
         """
         Set samples to load.
 
@@ -355,18 +405,28 @@ class PgenReader(object):
             Preserve sample order from pgen file.
         """
         if sample_ids is None:
-            self.sample_ids = self.sample_id_list
+            self.sample_ids = list(self.sample_id_list)
             self.sample_idxs = None
-        else:
-            sample_idxs = [self.sample_id_list.index(i) for i in sample_ids]
-            if sort:
-                sidx = np.argsort(sample_idxs)
-                sample_idxs = [sample_idxs[i] for i in sidx]
-                sample_ids = [sample_ids[i] for i in sidx]
-            self.sample_ids = sample_ids
-            self.sample_idxs = sample_idxs
+            return
 
-    def get_range(self, region, start=None, end=None):
+        selected_sample_ids: list[Any] = list(sample_ids)
+        selected_sample_idxs: list[int] = [
+            self.sample_id_list.index(sample_id) for sample_id in selected_sample_ids
+        ]
+
+        if sort:
+            sort_idx = np.argsort(selected_sample_idxs).tolist()
+            selected_sample_idxs = [
+                selected_sample_idxs[i] for i in sort_idx
+            ]
+            selected_sample_ids = [selected_sample_ids[i] for i in sort_idx]
+
+        self.sample_ids = selected_sample_ids
+        self.sample_idxs = selected_sample_idxs
+
+    def get_range(
+        self, region: str, start: int | None = None, end: int | None = None
+    ) -> npt.NDArray[np.int64]:
         """
         Get variant indexes corresponding to region specified as 'chr:start-end', or as chr, start, end.
 
@@ -385,95 +445,179 @@ class PgenReader(object):
             [start, end] indexes (inclusive)
         """
         if start is None and end is None:
-            if ':' in region:
-                chrom, pos = region.split(':')
-                start, end = [int(i) for i in pos.split('-')]
+            if ":" in region:
+                chrom, pos = region.split(":")
+                start, end = [int(i) for i in pos.split("-")]
             else:  # full chromosome selected
                 chrom = region
-                return self.variant_dfs[chrom]['index'].values[[0, -1]]
+                return self.variant_dfs[chrom]["index"].to_numpy(
+                    dtype=np.int64, copy=False
+                )[[0, -1]]
         else:  # input is chr, start, end
             chrom = region
 
-        lb = bisect.bisect_left(self.variant_dfs[chrom]['pos'].values, start)
-        ub = bisect.bisect_right(self.variant_dfs[chrom]['pos'].values, end)
+        assert start is not None and end is not None
+        lb = bisect.bisect_left(self.variant_dfs[chrom]["pos"].values, start)
+        ub = bisect.bisect_right(self.variant_dfs[chrom]["pos"].values, end)
         if lb != ub:
-            r = self.variant_dfs[chrom]['index'].values[[lb, ub - 1]]
+            r = self.variant_dfs[chrom]["index"].to_numpy(dtype=np.int64, copy=False)[
+                [lb, ub - 1]
+            ]
         else:
-            r = []
+            r = np.empty(0, dtype=np.int64)
         return r
 
-    def read(self, variant_id, impute_mean=True, dtype=np.float32):
+    def read(
+        self, variant_id: str, impute_mean: bool = True, dtype: DTypeLike = np.float32
+    ):
         """Read genotypes for an individual variant as 0,1,2,-9; impute missing values (-9) to mean (default)."""
         variant_idx = self.variant_idx_dict[variant_id]
-        genotypes = read(self.pgen_file, variant_idx, sample_subset=self.sample_idxs,
-                         dtype=np.int8).astype(dtype)
+        genotypes = read(
+            self.pgen_file, variant_idx, sample_subset=self.sample_idxs, dtype=np.int8
+        ).astype(dtype)
         if impute_mean:
             _impute_mean(genotypes)
         return pd.Series(genotypes, index=self.sample_ids, name=variant_id)
 
-    def read_list(self, variant_ids, impute_mean=True, dtype=np.float32):
+    def read_list(
+        self,
+        variant_ids: Sequence[str],
+        impute_mean: bool = True,
+        dtype: DTypeLike = np.float32,
+    ):
         """Read genotypes for an list of variants as 0,1,2,-9; impute missing values (-9) to mean (default)."""
         variant_idxs = [self.variant_idx_dict[i] for i in variant_ids]
-        genotypes = read_list(self.pgen_file, variant_idxs, sample_subset=self.sample_idxs,
-                              dtype=np.int8).astype(dtype)
+        genotypes = read_list(
+            self.pgen_file, variant_idxs, sample_subset=self.sample_idxs, dtype=np.int8
+        ).astype(dtype)
         if impute_mean:
             _impute_mean(genotypes)
-        return pd.DataFrame(genotypes, index=variant_ids, columns=self.sample_ids)
+        return pd.DataFrame(genotypes, index=list(variant_ids), columns=self.sample_ids)
 
-    def read_range(self, start_idx, end_idx, impute_mean=True, dtype=np.float32):
+    def read_range(
+        self,
+        start_idx: int,
+        end_idx: int,
+        impute_mean: bool = True,
+        dtype: DTypeLike = np.float32,
+    ):
         """Read genotypes for range of variants as 0,1,2,-9; impute missing values (-9) to mean (default)."""
-        genotypes = read_range(self.pgen_file, start_idx, end_idx, sample_subset=self.sample_idxs,
-                               dtype=np.int8).astype(dtype)
+        genotypes = read_range(
+            self.pgen_file,
+            start_idx,
+            end_idx,
+            sample_subset=self.sample_idxs,
+            dtype=np.int8,
+        ).astype(dtype)
         if impute_mean:
             _impute_mean(genotypes)
-        return pd.DataFrame(genotypes, index=self.variant_ids[start_idx:end_idx+1], columns=self.sample_ids)
+        return pd.DataFrame(
+            genotypes,
+            index=self.variant_ids[start_idx : end_idx + 1],
+            columns=self.sample_ids,
+        )
 
-    def read_region(self, region, start_pos=None, end_pos=None, impute_mean=True, dtype=np.float32):
+    def read_region(
+        self,
+        region: str,
+        start_pos: int | None = None,
+        end_pos: int | None = None,
+        impute_mean: bool = True,
+        dtype: DTypeLike = np.float32,
+    ):
         """Read genotypes for variants in a genomic region as 0,1,2,-9; impute missing values (-9) to mean (default)."""
         r = self.get_range(region, start_pos, end_pos)
         if len(r) > 0:
             return self.read_range(*r, impute_mean=impute_mean, dtype=dtype)
 
-    def read_dosages(self, variant_id, dtype=np.float32):
+    def read_dosages(self, variant_id: str, dtype: DTypeLike = np.float32):
         variant_idx = self.variant_idx_dict[variant_id]
-        dosages = read_dosages(self.pgen_file, variant_idx, sample_subset=self.sample_idxs, dtype=dtype)
+        dosages = read_dosages(
+            self.pgen_file, variant_idx, sample_subset=self.sample_idxs, dtype=dtype
+        )
         return pd.Series(dosages, index=self.sample_ids, name=variant_id)
 
-    def read_dosages_list(self, variant_ids, dtype=np.float32):
+    def read_dosages_list(
+        self, variant_ids: Sequence[str], dtype: DTypeLike = np.float32
+    ):
         variant_idxs = [self.variant_idx_dict[i] for i in variant_ids]
-        dosages = read_dosages_list(self.pgen_file, variant_idxs, sample_subset=self.sample_idxs, dtype=dtype)
-        return pd.DataFrame(dosages, index=variant_ids, columns=self.sample_ids)
+        dosages = read_dosages_list(
+            self.pgen_file, variant_idxs, sample_subset=self.sample_idxs, dtype=dtype
+        )
+        return pd.DataFrame(dosages, index=list(variant_ids), columns=self.sample_ids)
 
-    def read_dosages_range(self, start_idx, end_idx, dtype=np.float32):
-        dosages = read_dosages_range(self.pgen_file, start_idx, end_idx, sample_subset=self.sample_idxs, dtype=dtype)
-        return pd.DataFrame(dosages, index=self.variant_ids[start_idx:end_idx+1], columns=self.sample_ids)
+    def read_dosages_range(
+        self, start_idx: int, end_idx: int, dtype: DTypeLike = np.float32
+    ):
+        dosages = read_dosages_range(
+            self.pgen_file,
+            start_idx,
+            end_idx,
+            sample_subset=self.sample_idxs,
+            dtype=dtype,
+        )
+        return pd.DataFrame(
+            dosages,
+            index=self.variant_ids[start_idx : end_idx + 1],
+            columns=self.sample_ids,
+        )
 
-    def read_dosages_region(self, region, start_pos=None, end_pos=None, dtype=np.float32):
+    def read_dosages_region(
+        self,
+        region: str,
+        start_pos: int | None = None,
+        end_pos: int | None = None,
+        dtype: DTypeLike = np.float32,
+    ):
         r = self.get_range(region, start_pos, end_pos)
         if len(r) > 0:
             return self.read_dosages_range(*r, dtype=dtype)
 
-    def read_alleles(self, variant_id):
+    def read_alleles(self, variant_id: str):
         variant_idx = self.variant_idx_dict[variant_id]
-        alleles = read_alleles(self.pgen_file, variant_idx, sample_subset=self.sample_idxs)
-        s1 = pd.Series(alleles[::2],  index=self.sample_ids, name=variant_id)
+        alleles = read_alleles(
+            self.pgen_file, variant_idx, sample_subset=self.sample_idxs
+        )
+        s1 = pd.Series(alleles[::2], index=self.sample_ids, name=variant_id)
         s2 = pd.Series(alleles[1::2], index=self.sample_ids, name=variant_id)
         return s1, s2
 
-    def read_alleles_list(self, variant_ids):
+    def read_alleles_list(
+        self, variant_ids: Sequence[str]
+    ) -> tuple[pd.DataFrame, pd.DataFrame]:
         variant_idxs = [self.variant_idx_dict[i] for i in variant_ids]
-        alleles = read_alleles_list(self.pgen_file, variant_idxs, sample_subset=self.sample_idxs)
-        df1 = pd.DataFrame(alleles[:,::2],  index=variant_ids, columns=self.sample_ids)
-        df2 = pd.DataFrame(alleles[:,1::2], index=variant_ids, columns=self.sample_ids)
+        alleles = read_alleles_list(
+            self.pgen_file, variant_idxs, sample_subset=self.sample_idxs
+        )
+        df1 = pd.DataFrame(
+            alleles[:, ::2], index=list(variant_ids), columns=self.sample_ids
+        )
+        df2 = pd.DataFrame(
+            alleles[:, 1::2], index=list(variant_ids), columns=self.sample_ids
+        )
         return df1, df2
 
-    def read_alleles_range(self, start_idx, end_idx):
-        alleles = read_alleles_range(self.pgen_file, start_idx, end_idx, sample_subset=self.sample_idxs)
-        df1 = pd.DataFrame(alleles[:,::2],  index=self.variant_ids[start_idx:end_idx+1], columns=self.sample_ids)
-        df2 = pd.DataFrame(alleles[:,1::2], index=self.variant_ids[start_idx:end_idx+1], columns=self.sample_ids)
+    def read_alleles_range(
+        self, start_idx: int, end_idx: int
+    ) -> tuple[pd.DataFrame, pd.DataFrame]:
+        alleles = read_alleles_range(
+            self.pgen_file, start_idx, end_idx, sample_subset=self.sample_idxs
+        )
+        df1 = pd.DataFrame(
+            alleles[:, ::2],
+            index=self.variant_ids[start_idx : end_idx + 1],
+            columns=self.sample_ids,
+        )
+        df2 = pd.DataFrame(
+            alleles[:, 1::2],
+            index=self.variant_ids[start_idx : end_idx + 1],
+            columns=self.sample_ids,
+        )
         return df1, df2
 
-    def read_alleles_region(self, region, start_pos=None, end_pos=None):
+    def read_alleles_region(
+        self, region: str, start_pos: int | None = None, end_pos: int | None = None
+    ):
         r = self.get_range(region, start_pos, end_pos)
         if len(r) > 0:
             return self.read_alleles_range(*r)
@@ -482,18 +626,26 @@ class PgenReader(object):
 
     def load_genotypes(self):
         """Load all genotypes as np.int8, without imputing missing values."""
-        genotypes = read_range(self.pgen_file, 0, self.num_variants-1, sample_subset=self.sample_idxs)
+        genotypes = read_range(
+            self.pgen_file, 0, self.num_variants - 1, sample_subset=self.sample_idxs
+        )
         return pd.DataFrame(genotypes, index=self.variant_ids, columns=self.sample_ids)
 
     def load_dosages(self):
         """Load all dosages."""
-        return self.read_dosages_range(0, self.num_variants-1)
+        return self.read_dosages_range(0, self.num_variants - 1)
 
     def load_alleles(self):
         """Load all alleles."""
-        return self.read_alleles_range(0, self.num_variants-1)
+        return self.read_alleles_range(0, self.num_variants - 1)
 
-    def get_pairwise_ld(self, id1, id2, r2=True, dtype=np.float32):
+    def get_pairwise_ld(
+        self,
+        id1: str | Sequence[str],
+        id2: str | Sequence[str],
+        r2: bool = True,
+        dtype: DTypeLike = np.float32,
+    ):
         """Compute pairwise LD (R2) between (lists of) variants"""
         if isinstance(id1, str) and isinstance(id2, str):
             g1 = self.read(id1, dtype=dtype)
@@ -501,27 +653,27 @@ class PgenReader(object):
             g1 -= g1.mean()
             g2 -= g2.mean()
             if r2:
-                r = (g1 * g2).sum()**2 / ( (g1**2).sum() * (g2**2).sum() )
+                r = (g1 * g2).sum() ** 2 / ((g1**2).sum() * (g2**2).sum())
             else:
-                r = (g1 * g2).sum() / np.sqrt( (g1**2).sum() * (g2**2).sum() )
+                r = (g1 * g2).sum() / np.sqrt((g1**2).sum() * (g2**2).sum())
         elif isinstance(id1, str):
             g1 = self.read(id1, dtype=dtype)
             g2 = self.read_list(id2, dtype=dtype)
             g1 -= g1.mean()
             g2 -= g2.values.mean(1, keepdims=True)
             if r2:
-                r = (g1 * g2).sum(1)**2 / ( (g1**2).sum() * (g2**2).sum(1) )
+                r = (g1 * g2).sum(1) ** 2 / ((g1**2).sum() * (g2**2).sum(1))
             else:
-                r = (g1 * g2).sum(1) / np.sqrt( (g1**2).sum() * (g2**2).sum(1) )
+                r = (g1 * g2).sum(1) / np.sqrt((g1**2).sum() * (g2**2).sum(1))
         elif isinstance(id2, str):
             g1 = self.read_list(id1, dtype=dtype)
             g2 = self.read(id2, dtype=dtype)
             g1 -= g1.values.mean(1, keepdims=True)
             g2 -= g2.mean()
             if r2:
-                r = (g1 * g2).sum(1)**2 / ( (g1**2).sum(1) * (g2**2).sum() )
+                r = (g1 * g2).sum(1) ** 2 / ((g1**2).sum(1) * (g2**2).sum())
             else:
-                r = (g1 * g2).sum(1) / np.sqrt( (g1**2).sum(1) * (g2**2).sum() )
+                r = (g1 * g2).sum(1) / np.sqrt((g1**2).sum(1) * (g2**2).sum())
         else:
             assert len(id1) == len(id2)
             g1 = self.read_list(id1, dtype=dtype).values
@@ -529,17 +681,23 @@ class PgenReader(object):
             g1 -= g1.mean(1, keepdims=True)
             g2 -= g2.mean(1, keepdims=True)
             if r2:
-                r = (g1 * g2).sum(1) ** 2 / ( (g1**2).sum(1) * (g2**2).sum(1) )
+                r = (g1 * g2).sum(1) ** 2 / ((g1**2).sum(1) * (g2**2).sum(1))
             else:
-                r = (g1 * g2).sum(1) / np.sqrt( (g1**2).sum(1) * (g2**2).sum(1) )
+                r = (g1 * g2).sum(1) / np.sqrt((g1**2).sum(1) * (g2**2).sum(1))
         return r
 
-    def get_ld_matrix(self, variant_ids, dtype=np.float32):
+    def get_ld_matrix(
+        self, variant_ids: Sequence[str], dtype: DTypeLike = np.float32
+    ) -> pd.DataFrame:
         g = self.read_list(variant_ids, dtype=dtype).values
-        return pd.DataFrame(np.corrcoef(g), index=variant_ids, columns=variant_ids)
+        return pd.DataFrame(
+            np.corrcoef(g), index=list(variant_ids), columns=list(variant_ids)
+        )
 
 
-def load_dosages_df(plink_prefix_path, select_samples=None):
+def load_dosages_df(
+    plink_prefix_path: str, select_samples: Sequence[str] | None = None
+) -> pd.DataFrame:
     """
     Load dosages for all variants and all/selected samples as a dataframe.
 
@@ -555,5 +713,5 @@ def load_dosages_df(plink_prefix_path, select_samples=None):
     dosages_df : pd.DataFrame (variants x samples)
         Genotype dosages for the selected samples.
     """
-    p = Pgen(plink_prefix_path, select_samples=select_samples)
-    return p.load_dosages_df()
+    p = PgenReader(plink_prefix_path, select_samples=select_samples)
+    return p.load_dosages()

--- a/tensorqtl/post.py
+++ b/tensorqtl/post.py
@@ -1,63 +1,93 @@
+import glob
+import os
+import sys
+from datetime import datetime
+from typing import Any, cast
+
 import numpy as np
 import pandas as pd
-import torch
 import scipy.stats as stats
-import subprocess
-import sys
-import os
-import glob
-from datetime import datetime
+import torch
 
 sys.path.insert(1, os.path.dirname(__file__))
-from core import *
 import mixqtl
 import qtl.genotype as gt
+from core import (
+    SimpleLogger,
+    Residualizer,
+    calculate_interaction_nominal,
+    center_normalize,
+    get_allele_stats,
+    has_rpy2,
+    impute_mean,
+    rfunc,
+)
 
 
-def calculate_qvalues(res_df, fdr=0.05, qvalue_lambda=None, logger=None):
+def calculate_qvalues(
+    res_df: pd.DataFrame,
+    fdr: float = 0.05,
+    qvalue_lambda: float | None = None,
+    logger: SimpleLogger | None = None,
+) -> None:
     """Annotate permutation results with q-values, p-value threshold"""
     if logger is None:
         logger = SimpleLogger()
 
-    logger.write('Computing q-values')
-    logger.write(f'  * Number of phenotypes tested: {res_df.shape[0]}')
+    logger.write("Computing q-values")
+    logger.write(f"  * Number of phenotypes tested: {res_df.shape[0]}")
 
-    if not res_df['pval_beta'].isnull().all():
-        pval_col = 'pval_beta'
-        r = stats.pearsonr(res_df['pval_perm'], res_df['pval_beta'])[0]
-        logger.write(f'  * Correlation between Beta-approximated and empirical p-values: {r:.4f}')
+    if not res_df["pval_beta"].isnull().all():
+        pval_col = "pval_beta"
+        r = stats.pearsonr(res_df["pval_perm"], res_df["pval_beta"])[0]
+        logger.write(
+            f"  * Correlation between Beta-approximated and empirical p-values: {r:.4f}"
+        )
     else:
-        pval_col = 'pval_perm'
-        logger.write(f'  * WARNING: no beta-approximated p-values found, using permutation p-values instead.')
+        pval_col = "pval_perm"
+        logger.write(
+            "  * WARNING: no beta-approximated p-values found, using permutation p-values instead."
+        )
 
     # calculate q-values
     if qvalue_lambda is not None:
-        logger.write(f'  * Calculating q-values with lambda = {qvalue_lambda:.3f}')
+        logger.write(f"  * Calculating q-values with lambda = {qvalue_lambda:.3f}")
     qval, pi0 = rfunc.qvalue(res_df[pval_col], lambda_qvalue=qvalue_lambda)
 
-    res_df['qval'] = qval
-    logger.write(f'  * Proportion of significant phenotypes (1-pi0): {1-pi0:.2f}')
+    res_df["qval"] = qval
+    logger.write(f"  * Proportion of significant phenotypes (1-pi0): {1 - pi0:.2f}")
     logger.write(f"  * QTL phenotypes @ FDR {fdr:.2f}: {(res_df['qval'] <= fdr).sum()}")
 
     # determine global min(p) significance threshold and calculate nominal p-value threshold for each gene
-    if pval_col == 'pval_beta':
-        lb = res_df.loc[res_df['qval'] <= fdr, 'pval_beta'].sort_values()
-        ub = res_df.loc[res_df['qval'] > fdr, 'pval_beta'].sort_values()
+    if pval_col == "pval_beta":
+        lb = res_df.loc[res_df["qval"] <= fdr, "pval_beta"].sort_values()
+        ub = res_df.loc[res_df["qval"] > fdr, "pval_beta"].sort_values()
 
         if len(lb) > 0:  # significant phenotypes
             lb = lb.iloc[-1]
             if len(ub) > 0:
                 ub = ub.iloc[0]
-                pthreshold = (lb+ub)/2
+                pthreshold = (lb + ub) / 2
             else:
                 pthreshold = lb
-            logger.write(f'  * min p-value threshold @ FDR {fdr}: {pthreshold:.6g}')
-            res_df['pval_nominal_threshold'] = stats.beta.ppf(pthreshold, res_df['beta_shape1'], res_df['beta_shape2'])
+            logger.write(f"  * min p-value threshold @ FDR {fdr}: {pthreshold:.6g}")
+            res_df["pval_nominal_threshold"] = stats.beta.ppf(
+                pthreshold, res_df["beta_shape1"], res_df["beta_shape2"]
+            )
 
 
-def calculate_afc(assoc_df, counts_df, genotype_df, variant_df=None, covariates_df=None,
-                  select_covariates=True, group='gene_id',
-                  imputation='offset', count_threshold=0, verbose=True):
+def calculate_afc(
+    assoc_df: pd.DataFrame,
+    counts_df: pd.DataFrame,
+    genotype_df: pd.DataFrame | gt.GenotypeIndexer,
+    variant_df: pd.DataFrame | None = None,
+    covariates_df: pd.DataFrame | None = None,
+    select_covariates: bool = True,
+    group: str = "gene_id",
+    imputation: str = "offset",
+    count_threshold: int = 0,
+    verbose: bool = True,
+) -> pd.DataFrame:
     """
     Calculate allelic fold-change (aFC) for variant-gene pairs
 
@@ -83,11 +113,15 @@ def calculate_afc(assoc_df, counts_df, genotype_df, variant_df=None, covariates_
     else:
         assert isinstance(genotype_df, gt.GenotypeIndexer)
         gi = genotype_df
-    genotype_ix = np.array([gi.genotype_df.columns.tolist().index(i) for i in counts_df.columns])
+    genotype_ix = np.array(
+        [gi.genotype_df.columns.tolist().index(i) for i in counts_df.columns]
+    )
     genotype_ix_t = torch.from_numpy(genotype_ix).to(device)
 
     if covariates_df is not None:
-        covariates_t = torch.tensor(covariates_df.values, dtype=torch.float32).to(device)
+        covariates_t = torch.tensor(covariates_df.values, dtype=torch.float32).to(
+            device
+        )
     else:
         covariates_t = None
 
@@ -95,53 +129,91 @@ def calculate_afc(assoc_df, counts_df, genotype_df, variant_df=None, covariates_
     n = len(assoc_df[group].unique())
     for k, (phenotype_id, gdf) in enumerate(assoc_df.groupby(group, sort=False), 1):
         if verbose and k % 10 == 0 or k == n:
-            print(f"\rCalculating aFC for {group.replace('_id','')} {k}/{n}", end='' if k != n else None, flush=True)
+            print(
+                f"\rCalculating aFC for {group.replace('_id', '')} {k}/{n}",
+                end="" if k != n else None,
+                flush=True,
+            )
 
-        counts_t = torch.tensor(counts_df.loc[phenotype_id].values,
-                                dtype=torch.float32).to(device)
-        genotypes_t = torch.tensor(gi.get_genotypes(gdf['variant_id'].tolist()), dtype=torch.float32).to(device)
-        genotypes_t = genotypes_t[:,genotype_ix_t]
+        counts_t = torch.tensor(
+            counts_df.loc[phenotype_id].values, dtype=torch.float32
+        ).to(device)
+        genotypes_t = torch.tensor(
+            gi.get_genotypes(gdf["variant_id"].tolist()), dtype=torch.float32
+        ).to(device)
+        genotypes_t = genotypes_t[:, genotype_ix_t]
         impute_mean(genotypes_t)
         try:
-            b, b_se = mixqtl.trc(genotypes_t, counts_t, covariates_t=covariates_t,
-                                 select_covariates=select_covariates, count_threshold=count_threshold,
-                                 imputation=imputation, mode='multi', return_af=False)
-            gdf['afc'] = b.cpu().numpy() * np.log2(np.e)
-            gdf['afc_se'] = b_se.cpu().numpy() * np.log2(np.e)
+            trc_result = cast(
+                tuple[Any, Any],
+                mixqtl.trc(
+                    genotypes_t,
+                    counts_t,
+                    covariates_t=covariates_t,
+                    select_covariates=select_covariates,
+                    count_threshold=count_threshold,
+                    imputation=imputation,
+                    mode="multi",
+                    return_af=False,
+                ),
+            )
+            b, b_se = trc_result
+            gdf["afc"] = b.cpu().numpy() * np.log2(np.e)
+            gdf["afc_se"] = b_se.cpu().numpy() * np.log2(np.e)
             afc_df.append(gdf)
         except:
-            print(f'WARNING: aFC calculation failed for {phenotype_id}')
+            print(f"WARNING: aFC calculation failed for {phenotype_id}")
     afc_df = pd.concat(afc_df)
 
     return afc_df
 
 
-def calculate_replication(res_df, genotypes, phenotype_df, covariates_df=None, paired_covariate_df=None,
-                          interaction_s=None, compute_pi1=False, lambda_qvalue=None, logp=False):
+def calculate_replication(
+    res_df: pd.DataFrame,
+    genotypes: pd.DataFrame | Any,
+    phenotype_df: pd.DataFrame,
+    covariates_df: pd.DataFrame | None = None,
+    paired_covariate_df: pd.DataFrame | None = None,
+    interaction_s: pd.Series | None = None,
+    compute_pi1: bool = False,
+    lambda_qvalue: float | None = None,
+    logp: bool = False,
+) -> pd.DataFrame | tuple[float, pd.DataFrame]:
     """res_df: DataFrame with 'variant_id' column and phenotype IDs as index"""
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 
     if paired_covariate_df is not None:
+        assert covariates_df is not None
         assert paired_covariate_df.index.equals(covariates_df.index)
         assert paired_covariate_df.columns.isin(phenotype_df.index).all()
 
     if isinstance(genotypes, pd.DataFrame):
-        genotypes_t = torch.tensor(genotypes.loc[res_df['variant_id']].values, dtype=torch.float).to(device)
-        genotype_ix = np.array([genotypes.columns.tolist().index(i) for i in phenotype_df.columns])
+        genotypes_t = torch.tensor(
+            genotypes.loc[res_df["variant_id"]].values, dtype=torch.float
+        ).to(device)
+        genotype_ix = np.array(
+            [genotypes.columns.tolist().index(i) for i in phenotype_df.columns]
+        )
     else:  # pgen.PgenReader
-        gt_df = genotypes.read_list(res_df['variant_id'], impute_mean=False)
-        genotypes_t =  torch.tensor(gt_df.values, dtype=torch.float).to(device)
-        genotype_ix = np.array([gt_df.columns.tolist().index(i) for i in phenotype_df.columns])
+        gt_df = genotypes.read_list(res_df["variant_id"], impute_mean=False)
+        genotypes_t = torch.tensor(gt_df.values, dtype=torch.float).to(device)
+        genotype_ix = np.array(
+            [gt_df.columns.tolist().index(i) for i in phenotype_df.columns]
+        )
 
     genotype_ix_t = torch.from_numpy(genotype_ix).to(device)
-    genotypes_t = genotypes_t[:,genotype_ix_t]
+    genotypes_t = genotypes_t[:, genotype_ix_t]
     impute_mean(genotypes_t)
     af_t, ma_samples_t, ma_count_t = get_allele_stats(genotypes_t)
 
-    phenotypes_t = torch.tensor(phenotype_df.loc[res_df.index].values, dtype=torch.float32).to(device)
+    phenotypes_t = torch.tensor(
+        phenotype_df.loc[res_df.index].values, dtype=torch.float32
+    ).to(device)
 
     if covariates_df is not None:
-        residualizer = Residualizer(torch.tensor(covariates_df.values, dtype=torch.float32).to(device))
+        residualizer = Residualizer(
+            torch.tensor(covariates_df.values, dtype=torch.float32).to(device)
+        )
         # dof -= covariates_df.shape[1]
     else:
         residualizer = None
@@ -149,25 +221,35 @@ def calculate_replication(res_df, genotypes, phenotype_df, covariates_df=None, p
     if interaction_s is None:
         if paired_covariate_df is None:
             if residualizer is not None:
-                genotype_res_t = residualizer.transform(genotypes_t)  # variants x samples
-                phenotype_res_t = residualizer.transform(phenotypes_t)  # phenotypes x samples
+                genotype_res_t = residualizer.transform(
+                    genotypes_t
+                )  # variants x samples
+                phenotype_res_t = residualizer.transform(
+                    phenotypes_t
+                )  # phenotypes x samples
                 dof = residualizer.dof
                 dof_t = dof
             else:
                 genotype_res_t = genotypes_t
                 phenotype_res_t = phenotypes_t
-                dof =  phenotypes_t.shape[1] - 2
+                dof = phenotypes_t.shape[1] - 2
                 dof_t = dof
         else:
             genotype_res_t = torch.zeros_like(genotypes_t).to(device)
             phenotype_res_t = torch.zeros_like(phenotypes_t).to(device)
             dof = []
-            for k,phenotype_id in enumerate(res_df.index):
+            assert covariates_df is not None
+            for k, phenotype_id in enumerate(res_df.index):
                 if phenotype_id in paired_covariate_df:
-                    iresidualizer = Residualizer(torch.tensor(np.c_[covariates_df, paired_covariate_df[phenotype_id]],
-                                                              dtype=torch.float32).to(device))
+                    iresidualizer = Residualizer(
+                        torch.tensor(
+                            np.c_[covariates_df, paired_covariate_df[phenotype_id]],
+                            dtype=torch.float32,
+                        ).to(device)
+                    )
                 else:
                     iresidualizer = residualizer
+                assert iresidualizer is not None
                 genotype_res_t[[k]] = iresidualizer.transform(genotypes_t[[k]])
                 phenotype_res_t[[k]] = iresidualizer.transform(phenotypes_t[[k]])
                 dof.append(iresidualizer.dof)
@@ -188,18 +270,43 @@ def calculate_replication(res_df, genotypes, phenotype_df, covariates_df=None, p
         tstat_t = torch.sqrt((dof_t * r2_nominal_t) / (1 - r2_nominal_t))
         slope_t = r_nominal_t * std_ratio_t
         slope_se_t = (slope_t.abs().double() / tstat_t).float()
-        pval = 2*stats.t.cdf(-np.abs(tstat_t.cpu()), dof)
+        pval = 2 * stats.t.cdf(-np.abs(tstat_t.cpu()), dof)
 
-        rep_df = pd.DataFrame(np.c_[res_df.index, res_df['variant_id'], ma_samples_t.cpu(), ma_count_t.cpu(), af_t.cpu(), pval, slope_t.cpu(), slope_se_t.cpu()],
-                              columns=['phenotype_id', 'variant_id', 'ma_samples', 'ma_count', 'af', 'pval_nominal', 'slope', 'slope_se']).infer_objects()
+        rep_df = pd.DataFrame(
+            np.c_[
+                res_df.index,
+                res_df["variant_id"],
+                ma_samples_t.cpu(),
+                ma_count_t.cpu(),
+                af_t.cpu(),
+                pval,
+                slope_t.cpu(),
+                slope_se_t.cpu(),
+            ],
+            columns=[
+                "phenotype_id",
+                "variant_id",
+                "ma_samples",
+                "ma_count",
+                "af",
+                "pval_nominal",
+                "slope",
+                "slope_se",
+            ],
+        ).infer_objects()
 
     else:
         if paired_covariate_df is not None:
-            raise NotImplementedError("Paired covariates are not yet supported for interactions")
+            raise NotImplementedError(
+                "Paired covariates are not yet supported for interactions"
+            )
 
-        interaction_t = torch.tensor(interaction_s.values.reshape(1,-1), dtype=torch.float32).to(device)
+        interaction_t = torch.tensor(
+            interaction_s.values.reshape(1, -1), dtype=torch.float32
+        ).to(device)
         ng, ns = genotypes_t.shape
         nps = phenotypes_t.shape[0]
+        assert residualizer is not None
 
         # centered inputs
         g0_t = genotypes_t - genotypes_t.mean(1, keepdim=True)
@@ -217,22 +324,56 @@ def calculate_replication(res_df, genotypes, phenotype_df, covariates_df=None, p
 
         # regression (in float; loss of precision may occur in edge cases)
         X_t = torch.stack([g0_t, i0_t, gi0_t], 2)  # ng x ns x 3
-        Xinv = torch.matmul(torch.transpose(X_t, 1, 2), X_t).inverse() # ng x 3 x 3
-        b_t = (torch.matmul(Xinv, torch.transpose(X_t, 1, 2)) * p0_t.unsqueeze(1)).sum(2) # ng x 3
+        Xinv = torch.matmul(torch.transpose(X_t, 1, 2), X_t).inverse()  # ng x 3 x 3
+        b_t = (torch.matmul(Xinv, torch.transpose(X_t, 1, 2)) * p0_t.unsqueeze(1)).sum(
+            2
+        )  # ng x 3
         r_t = (X_t * b_t.unsqueeze(1)).sum(2) - p0_t
         dof = residualizer.dof - 2
-        rss_t = (r_t*r_t).sum(1)  # ng x np
-        b_se_t = torch.sqrt( Xinv[:, torch.eye(3, dtype=torch.uint8).bool()] * rss_t.unsqueeze(-1) / dof )
+        rss_t = (r_t * r_t).sum(1)  # ng x np
+        b_se_t = torch.sqrt(
+            Xinv[:, torch.eye(3, dtype=torch.uint8).bool()] * rss_t.unsqueeze(-1) / dof
+        )
         tstat_t = (b_t.double() / b_se_t.double()).float()
-        pval = 2*stats.t.cdf(-np.abs(tstat_t.cpu()), dof)
+        pval = 2 * stats.t.cdf(-np.abs(tstat_t.cpu()), dof)
         b = b_t.cpu()
         b_se = b_se_t.cpu()
 
-        rep_df = pd.DataFrame(np.c_[res_df.index, res_df['variant_id'], ma_samples_t.cpu(), ma_count_t.cpu(), af_t.cpu(),
-                                    pval[:,0], b[:,0], b_se[:,0], pval[:,1], b[:,1], b_se[:,1], pval[:,2], b[:,2], b_se[:,2]],
-                              columns=['phenotype_id', 'variant_id', 'ma_samples', 'ma_count', 'af',
-                                       'pval_g', 'b_g', 'b_g_se', 'pval_i', 'b_i', 'b_i_se', 'pval_gi', 'b_gi', 'b_gi_se']).infer_objects()
-        pval = pval[:,2]
+        rep_df = pd.DataFrame(
+            np.c_[
+                res_df.index,
+                res_df["variant_id"],
+                ma_samples_t.cpu(),
+                ma_count_t.cpu(),
+                af_t.cpu(),
+                pval[:, 0],
+                b[:, 0],
+                b_se[:, 0],
+                pval[:, 1],
+                b[:, 1],
+                b_se[:, 1],
+                pval[:, 2],
+                b[:, 2],
+                b_se[:, 2],
+            ],
+            columns=[
+                "phenotype_id",
+                "variant_id",
+                "ma_samples",
+                "ma_count",
+                "af",
+                "pval_g",
+                "b_g",
+                "b_g_se",
+                "pval_i",
+                "b_i",
+                "b_i_se",
+                "pval_gi",
+                "b_gi",
+                "b_gi_se",
+            ],
+        ).infer_objects()
+        pval = pval[:, 2]
 
     if compute_pi1:
         try:
@@ -244,7 +385,11 @@ def calculate_replication(res_df, genotypes, phenotype_df, covariates_df=None, p
         return rep_df
 
 
-def annotate_genes(gene_df, annotation_gtf, lookup_df=None):
+def annotate_genes(
+    gene_df: pd.DataFrame,
+    annotation_gtf: str,
+    lookup_df: pd.DataFrame | None = None,
+) -> pd.DataFrame:
     """
     Add gene and variant annotations (e.g., gene_name, rs_id, etc.) to gene-level output
 
@@ -253,90 +398,156 @@ def annotate_genes(gene_df, annotation_gtf, lookup_df=None):
     lookup_df:      DataFrame with variant annotations, indexed by 'variant_id'
     """
     gene_dict = {}
-    print('['+datetime.now().strftime("%b %d %H:%M:%S")+'] Adding gene and variant annotations', flush=True)
-    print('  * parsing GTF', flush=True)
+    print(
+        "["
+        + datetime.now().strftime("%b %d %H:%M:%S")
+        + "] Adding gene and variant annotations",
+        flush=True,
+    )
+    print("  * parsing GTF", flush=True)
     with open(annotation_gtf) as gtf:
         for row in gtf:
-            row = row.strip().split('\t')
-            if row[0][0] == '#' or row[2] != 'gene': continue
+            row = row.strip().split("\t")
+            if row[0][0] == "#" or row[2] != "gene":
+                continue
             # get gene_id and gene_name from attributes
-            attr = dict([i.split() for i in row[8].replace('"','').split(';') if i!=''])
+            attr = dict(
+                [i.split() for i in row[8].replace('"', "").split(";") if i != ""]
+            )
             # gene_name, gene_chr, gene_start, gene_end, strand
-            gene_dict[attr['gene_id']] = [attr['gene_name'], row[0], row[3], row[4], row[6]]
+            gene_dict[attr["gene_id"]] = [
+                attr["gene_name"],
+                row[0],
+                row[3],
+                row[4],
+                row[6],
+            ]
 
-    print('  * annotating genes', flush=True)
-    if 'group_id' in gene_df:
-        gene_info = pd.DataFrame(data=[gene_dict[i] for i in gene_df['group_id']],
-                                 columns=['gene_name', 'gene_chr', 'gene_start', 'gene_end', 'strand'],
-                                 index=gene_df.index)
+    print("  * annotating genes", flush=True)
+    if "group_id" in gene_df:
+        gene_info = pd.DataFrame(
+            data=[gene_dict[i] for i in gene_df["group_id"]],
+            columns=["gene_name", "gene_chr", "gene_start", "gene_end", "strand"],
+            index=gene_df.index,
+        )
     else:
-        gene_info = pd.DataFrame(data=[gene_dict[i] for i in gene_df.index],
-                                 columns=['gene_name', 'gene_chr', 'gene_start', 'gene_end', 'strand'],
-                                 index=gene_df.index)
+        gene_info = pd.DataFrame(
+            data=[gene_dict[i] for i in gene_df.index],
+            columns=["gene_name", "gene_chr", "gene_start", "gene_end", "strand"],
+            index=gene_df.index,
+        )
     gene_df = pd.concat([gene_info, gene_df], axis=1)
     assert np.all(gene_df.index == gene_info.index)
 
-    col_order = ['gene_name', 'gene_chr', 'gene_start', 'gene_end', 'strand',
-        'num_var', 'beta_shape1', 'beta_shape2', 'true_df', 'pval_true_df', 'variant_id']
-    if 'tss_distance' in gene_df:
-        col_order += ['tss_distance']
+    col_order = [
+        "gene_name",
+        "gene_chr",
+        "gene_start",
+        "gene_end",
+        "strand",
+        "num_var",
+        "beta_shape1",
+        "beta_shape2",
+        "true_df",
+        "pval_true_df",
+        "variant_id",
+    ]
+    if "tss_distance" in gene_df:
+        col_order += ["tss_distance"]
     else:
-        col_order += ['start_distance', 'end_distance']
+        col_order += ["start_distance", "end_distance"]
     if lookup_df is not None:
-        print('  * adding variant annotations from lookup table', flush=True)
-        gene_df = gene_df.join(lookup_df, on='variant_id')  # add variant information
+        print("  * adding variant annotations from lookup table", flush=True)
+        gene_df = gene_df.join(lookup_df, on="variant_id")  # add variant information
         col_order += list(lookup_df.columns)
-    col_order += ['ma_samples', 'ma_count', 'af', 'pval_nominal',
-                  'slope', 'slope_se', 'pval_perm', 'pval_beta']
-    if 'group_id' in gene_df:
-        col_order += ['group_id', 'group_size']
-    col_order += ['qval', 'pval_nominal_threshold']
+    col_order += [
+        "ma_samples",
+        "ma_count",
+        "af",
+        "pval_nominal",
+        "slope",
+        "slope_se",
+        "pval_perm",
+        "pval_beta",
+    ]
+    if "group_id" in gene_df:
+        col_order += ["group_id", "group_size"]
+    col_order += ["qval", "pval_nominal_threshold"]
     gene_df = gene_df[col_order]
-    print('done.', flush=True)
+    print("done.", flush=True)
     return gene_df
 
 
-def get_significant_pairs(res_df, nominal_files, group_s=None, fdr=0.05):
+def get_significant_pairs(
+    res_df: pd.DataFrame,
+    nominal_files: str | dict[str, str],
+    group_s: pd.Series | None = None,
+    fdr: float = 0.05,
+) -> pd.DataFrame:
     """Significant variant-phenotype pairs based on nominal p-value threshold for each phenotype"""
-    print('['+datetime.now().strftime("%b %d %H:%M:%S")+'] tensorQTL: parsing all significant variant-phenotype pairs', flush=True)
-    assert 'qval' in res_df
+    print(
+        "["
+        + datetime.now().strftime("%b %d %H:%M:%S")
+        + "] tensorQTL: parsing all significant variant-phenotype pairs",
+        flush=True,
+    )
+    assert "qval" in res_df
 
     # significant phenotypes (apply FDR threshold)
     if group_s is not None:
-        df = res_df.loc[res_df['qval'] <= fdr, ['pval_nominal_threshold', 'pval_nominal', 'pval_beta', 'group_id']].copy()
-        df.set_index('group_id', inplace=True)
+        df = res_df.loc[
+            res_df["qval"] <= fdr,
+            ["pval_nominal_threshold", "pval_nominal", "pval_beta", "group_id"],
+        ].copy()
+        df.set_index("group_id", inplace=True)
     else:
-        df = res_df.loc[res_df['qval'] <= fdr, ['pval_nominal_threshold', 'pval_nominal', 'pval_beta']].copy()
-    df.rename(columns={'pval_nominal': 'min_pval_nominal'}, inplace=True)
+        df = res_df.loc[
+            res_df["qval"] <= fdr,
+            ["pval_nominal_threshold", "pval_nominal", "pval_beta"],
+        ].copy()
+    df.rename(columns={"pval_nominal": "min_pval_nominal"}, inplace=True)
     signif_phenotype_ids = set(df.index)
-    threshold_dict = df['pval_nominal_threshold'].to_dict()
+    threshold_dict = df["pval_nominal_threshold"].to_dict()
 
     if isinstance(nominal_files, str):
         # chr -> file
-        nominal_files = {os.path.basename(i).split('.')[-2]:i for i in glob.glob(nominal_files+'*.parquet')}
+        nominal_files = {
+            os.path.basename(i).split(".")[-2]: i
+            for i in glob.glob(nominal_files + "*.parquet")
+        }
     else:
         assert isinstance(nominal_files, dict)
 
-    chroms = sorted(nominal_files.keys(), key=lambda x: int(x.replace('chr', '').replace('X', '23')))
+    chroms = sorted(
+        nominal_files.keys(), key=lambda x: int(x.replace("chr", "").replace("X", "23"))
+    )
     signif_df = []
-    for k,c in enumerate(chroms, 1):
-        print(f'  * processing chr. {k}/{len(chroms)}', end='\r', flush=True)
+    for k, c in enumerate(chroms, 1):
+        print(f"  * processing chr. {k}/{len(chroms)}", end="\r", flush=True)
         nominal_df = pd.read_parquet(nominal_files[c])
         # drop pairs that never pass threshold
-        nominal_df = nominal_df[nominal_df['pval_nominal'] <= df['pval_nominal_threshold'].max()]
+        nominal_df = nominal_df[
+            nominal_df["pval_nominal"] <= df["pval_nominal_threshold"].max()
+        ]
         if group_s is not None:
-            nominal_df.insert(1, 'group_id', nominal_df['phenotype_id'].map(group_s))
-            nominal_df = nominal_df[nominal_df['group_id'].isin(signif_phenotype_ids)]
-            m = nominal_df['pval_nominal'] < nominal_df['group_id'].apply(lambda x: threshold_dict[x])
+            nominal_df.insert(1, "group_id", nominal_df["phenotype_id"].map(group_s))
+            nominal_df = nominal_df[nominal_df["group_id"].isin(signif_phenotype_ids)]
+            m = nominal_df["pval_nominal"] < nominal_df["group_id"].apply(
+                lambda x: threshold_dict[x]
+            )
         else:
-            nominal_df = nominal_df[nominal_df['phenotype_id'].isin(signif_phenotype_ids)]
-            m = nominal_df['pval_nominal'] < nominal_df['phenotype_id'].apply(lambda x: threshold_dict[x])
+            nominal_df = nominal_df[
+                nominal_df["phenotype_id"].isin(signif_phenotype_ids)
+            ]
+            m = nominal_df["pval_nominal"] < nominal_df["phenotype_id"].apply(
+                lambda x: threshold_dict[x]
+            )
         signif_df.append(nominal_df[m])
     print()
     signif_df = pd.concat(signif_df, axis=0)
     if group_s is not None:
-        signif_df = signif_df.merge(df, left_on='group_id', right_index=True)
+        signif_df = signif_df.merge(df, left_on="group_id", right_index=True)
     else:
-        signif_df = signif_df.merge(df, left_on='phenotype_id', right_index=True)
-    print('['+datetime.now().strftime("%b %d %H:%M:%S")+'] done', flush=True)
+        signif_df = signif_df.merge(df, left_on="phenotype_id", right_index=True)
+    print("[" + datetime.now().strftime("%b %d %H:%M:%S") + "] done", flush=True)
     return signif_df.reset_index(drop=True)

--- a/tensorqtl/tensorqtl.py
+++ b/tensorqtl/tensorqtl.py
@@ -1,118 +1,264 @@
 #!/usr/bin/env python3
-from __future__ import print_function
-import pandas as pd
-import numpy as np
-from datetime import datetime
-import sys
-import os
-import re
-import pickle
 import argparse
-from collections import defaultdict
+import glob
 import importlib.metadata
+import os
+import pickle
+import re
+import sys
+from datetime import datetime
+
+import numpy as np
+import pandas as pd
+import torch
 
 sys.path.insert(1, os.path.dirname(__file__))
-from core import *
-from post import *
-import genotypeio, cis, trans, susie
+import cis
+import genotypeio
+import susie
+import trans
+from core import SimpleLogger, has_rpy2, read_phenotype_bed
+from post import calculate_qvalues, get_significant_pairs
 
 
-def main():
-    parser = argparse.ArgumentParser(description='tensorQTL: GPU-based QTL mapper')
-    parser.add_argument('genotype_path', help='Genotypes in PLINK format')
-    parser.add_argument('phenotypes', help="Phenotypes in BED format (.bed, .bed.gz, .bed.parquet), or optionally for 'trans' mode, parquet or tab-delimited.")
-    parser.add_argument('prefix', help='Prefix for output file names')
-    parser.add_argument('--mode', type=str, default='cis', choices=['cis', 'cis_nominal', 'cis_independent', 'cis_susie', 'trans', 'trans_susie'],
-                        help='Mapping mode. Default: cis')
-    parser.add_argument('--covariates', default=None, help='Covariates file, tab-delimited (covariates x samples)')
-    parser.add_argument('--paired_covariate', default=None, help='Single phenotype-specific covariate, tab-delimited (phenotypes x samples)')
-    parser.add_argument('--permutations', type=int, default=10000, help='Number of permutations. Default: 10000')
-    parser.add_argument('--interaction', default=None, type=str, help='Tab-delimited file mapping sample ID to interaction value(s) (if multiple interaction terms are used, the file must include a header with variable names)')
-    parser.add_argument('--cis_output', default=None, type=str, help="Output from 'cis' mode with q-values. Required for independent cis-QTL mapping.")
-    parser.add_argument('--phenotype_groups', default=None, type=str, help='Phenotype groups. Header-less TSV with two columns: phenotype_id, group_id')
-    parser.add_argument('--window', default=1000000, type=np.int32, help='Cis-window size, in bases. Default: 1000000.')
-    parser.add_argument('--pval_threshold', default=1e-5, type=np.float64, help='Output only significant phenotype-variant pairs with a p-value below threshold. Default: 1e-5 for trans-QTL')
-    parser.add_argument('--logp', action='store_true', help='Compute nominal p-values as -log10(P) for added precision (requires R)')
-    parser.add_argument('--maf_threshold', default=0, type=np.float64, help='Include only genotypes with minor allele frequency >= maf_threshold. Default: 0')
-    parser.add_argument('--maf_threshold_interaction', default=0.05, type=np.float64, help='MAF threshold for interactions, applied to lower and upper half of samples')
-    parser.add_argument('--dosages', action='store_true', help='Load dosages instead of genotypes (only applies to PLINK2 bgen input).')
-    parser.add_argument('--return_dense', action='store_true', help='Return dense output for trans-QTL.')
-    parser.add_argument('--return_r2', action='store_true', help='Return r2 (only for sparse trans-QTL output)')
-    parser.add_argument('--best_only', action='store_true', help='Only write lead association for each phenotype (interaction mode only)')
-    parser.add_argument('--output_text', action='store_true', help='Write output in txt.gz format instead of parquet (trans-QTL mode only)')
-    parser.add_argument('--batch_size', type=int, default=20000, help='GPU batch size (trans-QTLs only). Reduce this if encountering OOM errors.')
-    parser.add_argument('--chunk_size', default=None, help="For cis-QTL mapping, load genotypes into CPU memory in chunks of chunk_size variants, or by chromosome if chunk_size is 'chr'.")
-    parser.add_argument('--susie_loci', default=None, help="Table (parquet or tsv) with loci to fine-map (phenotype_id, chr, pos) with mode 'trans_susie'.")
-    parser.add_argument('--disable_beta_approx', action='store_true', help='Disable Beta-distribution approximation of empirical p-values (not recommended).')
-    parser.add_argument('--warn_monomorphic', action='store_true', help='Warn if monomorphic variants are found.')
-    parser.add_argument('--max_effects', type=int, default=10, help='Maximum number of non-zero effects in the SuSiE regression model.')
-    parser.add_argument('--fdr', default=0.05, type=np.float64, help='FDR for cis-QTLs')
-    parser.add_argument('--qvalue_lambda', default=None, type=np.float64, help='lambda parameter for pi0est in qvalue.')
-    parser.add_argument('--seed', default=None, type=int, help='Seed for permutations.')
-    parser.add_argument('-o', '--output_dir', default='.', help='Output directory')
+def main() -> None:
+    parser = argparse.ArgumentParser(description="tensorQTL: GPU-based QTL mapper")
+    parser.add_argument("genotype_path", help="Genotypes in PLINK format")
+    parser.add_argument(
+        "phenotypes",
+        help="Phenotypes in BED format (.bed, .bed.gz, .bed.parquet), or optionally for 'trans' mode, parquet or tab-delimited.",
+    )
+    parser.add_argument("prefix", help="Prefix for output file names")
+    parser.add_argument(
+        "--mode",
+        type=str,
+        default="cis",
+        choices=[
+            "cis",
+            "cis_nominal",
+            "cis_independent",
+            "cis_susie",
+            "trans",
+            "trans_susie",
+        ],
+        help="Mapping mode. Default: cis",
+    )
+    parser.add_argument(
+        "--covariates",
+        default=None,
+        help="Covariates file, tab-delimited (covariates x samples)",
+    )
+    parser.add_argument(
+        "--paired_covariate",
+        default=None,
+        help="Single phenotype-specific covariate, tab-delimited (phenotypes x samples)",
+    )
+    parser.add_argument(
+        "--permutations",
+        type=int,
+        default=10000,
+        help="Number of permutations. Default: 10000",
+    )
+    parser.add_argument(
+        "--interaction",
+        default=None,
+        type=str,
+        help="Tab-delimited file mapping sample ID to interaction value(s) (if multiple interaction terms are used, the file must include a header with variable names)",
+    )
+    parser.add_argument(
+        "--cis_output",
+        default=None,
+        type=str,
+        help="Output from 'cis' mode with q-values. Required for independent cis-QTL mapping.",
+    )
+    parser.add_argument(
+        "--phenotype_groups",
+        default=None,
+        type=str,
+        help="Phenotype groups. Header-less TSV with two columns: phenotype_id, group_id",
+    )
+    parser.add_argument(
+        "--window",
+        default=1000000,
+        type=np.int32,
+        help="Cis-window size, in bases. Default: 1000000.",
+    )
+    parser.add_argument(
+        "--pval_threshold",
+        default=1e-5,
+        type=np.float64,
+        help="Output only significant phenotype-variant pairs with a p-value below threshold. Default: 1e-5 for trans-QTL",
+    )
+    parser.add_argument(
+        "--logp",
+        action="store_true",
+        help="Compute nominal p-values as -log10(P) for added precision (requires R)",
+    )
+    parser.add_argument(
+        "--maf_threshold",
+        default=0,
+        type=np.float64,
+        help="Include only genotypes with minor allele frequency >= maf_threshold. Default: 0",
+    )
+    parser.add_argument(
+        "--maf_threshold_interaction",
+        default=0.05,
+        type=np.float64,
+        help="MAF threshold for interactions, applied to lower and upper half of samples",
+    )
+    parser.add_argument(
+        "--dosages",
+        action="store_true",
+        help="Load dosages instead of genotypes (only applies to PLINK2 bgen input).",
+    )
+    parser.add_argument(
+        "--return_dense", action="store_true", help="Return dense output for trans-QTL."
+    )
+    parser.add_argument(
+        "--return_r2",
+        action="store_true",
+        help="Return r2 (only for sparse trans-QTL output)",
+    )
+    parser.add_argument(
+        "--best_only",
+        action="store_true",
+        help="Only write lead association for each phenotype (interaction mode only)",
+    )
+    parser.add_argument(
+        "--output_text",
+        action="store_true",
+        help="Write output in txt.gz format instead of parquet (trans-QTL mode only)",
+    )
+    parser.add_argument(
+        "--batch_size",
+        type=int,
+        default=20000,
+        help="GPU batch size (trans-QTLs only). Reduce this if encountering OOM errors.",
+    )
+    parser.add_argument(
+        "--chunk_size",
+        default=None,
+        help="For cis-QTL mapping, load genotypes into CPU memory in chunks of chunk_size variants, or by chromosome if chunk_size is 'chr'.",
+    )
+    parser.add_argument(
+        "--susie_loci",
+        default=None,
+        help="Table (parquet or tsv) with loci to fine-map (phenotype_id, chr, pos) with mode 'trans_susie'.",
+    )
+    parser.add_argument(
+        "--disable_beta_approx",
+        action="store_true",
+        help="Disable Beta-distribution approximation of empirical p-values (not recommended).",
+    )
+    parser.add_argument(
+        "--warn_monomorphic",
+        action="store_true",
+        help="Warn if monomorphic variants are found.",
+    )
+    parser.add_argument(
+        "--max_effects",
+        type=int,
+        default=10,
+        help="Maximum number of non-zero effects in the SuSiE regression model.",
+    )
+    parser.add_argument("--fdr", default=0.05, type=np.float64, help="FDR for cis-QTLs")
+    parser.add_argument(
+        "--qvalue_lambda",
+        default=None,
+        type=np.float64,
+        help="lambda parameter for pi0est in qvalue.",
+    )
+    parser.add_argument("--seed", default=None, type=int, help="Seed for permutations.")
+    parser.add_argument("-o", "--output_dir", default=".", help="Output directory")
     args = parser.parse_args()
 
     # check inputs
-    if args.mode == 'cis_independent' and (args.cis_output is None or not os.path.exists(args.cis_output)):
+    if args.mode == "cis_independent" and (
+        args.cis_output is None or not os.path.exists(args.cis_output)
+    ):
         raise ValueError("Output from 'cis' mode must be provided.")
-    if args.interaction is not None and args.mode not in ['cis_nominal', 'trans']:
-        raise ValueError("Interactions are only supported in 'cis_nominal' or 'trans' mode.")
+    if args.interaction is not None and args.mode not in ["cis_nominal", "trans"]:
+        raise ValueError(
+            "Interactions are only supported in 'cis_nominal' or 'trans' mode."
+        )
 
-    logger = SimpleLogger(os.path.join(args.output_dir, f'{args.prefix}.tensorQTL.{args.mode}.log'))
-    logger.write(f'[{datetime.now().strftime("%b %d %H:%M:%S")}] Running TensorQTL v{importlib.metadata.version("tensorqtl")}: {args.mode.split("_")[0]}-QTL mapping')
+    logger = SimpleLogger(
+        os.path.join(args.output_dir, f"{args.prefix}.tensorQTL.{args.mode}.log")
+    )
+    logger.write(
+        f"[{datetime.now().strftime('%b %d %H:%M:%S')}] Running TensorQTL v{importlib.metadata.version('tensorqtl')}: {args.mode.split('_')[0]}-QTL mapping"
+    )
     if torch.cuda.is_available():
-        logger.write(f'  * using GPU ({torch.cuda.get_device_name(torch.cuda.current_device())})')
+        logger.write(
+            f"  * using GPU ({torch.cuda.get_device_name(torch.cuda.current_device())})"
+        )
     else:
-        logger.write('  * WARNING: using CPU!')
-    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+        logger.write("  * WARNING: using CPU!")
+
     if args.seed is not None:
-        logger.write(f'  * using seed {args.seed}')
+        logger.write(f"  * using seed {args.seed}")
 
     # load inputs
-    logger.write(f'  * reading phenotypes ({args.phenotypes})')
+    logger.write(f"  * reading phenotypes ({args.phenotypes})")
     # for cis modes, require BED input with position information
-    if args.mode.startswith('cis'):
-        assert args.phenotypes.lower().endswith(('.bed', '.bed.gz', '.bed.parquet')), "For cis modes, phenotypes must be in BED format."
+    if args.mode.startswith("cis"):
+        assert args.phenotypes.lower().endswith((".bed", ".bed.gz", ".bed.parquet")), (
+            "For cis modes, phenotypes must be in BED format."
+        )
         phenotype_df, phenotype_pos_df = read_phenotype_bed(args.phenotypes)
-        if phenotype_pos_df.columns[1] == 'pos':
+        if phenotype_pos_df.columns[1] == "pos":
             logger.write(f"  * cis-window detected as position ± {args.window:,}")
         else:
-            logger.write(f"  * cis-window detected as [start - {args.window:,}, end + {args.window:,}]")
-    elif args.mode.startswith('trans'):
-        if args.phenotypes.lower().endswith(('.bed', '.bed.gz', '.bed.parquet')):
+            logger.write(
+                f"  * cis-window detected as [start - {args.window:,}, end + {args.window:,}]"
+            )
+    elif args.mode.startswith("trans"):
+        if args.phenotypes.lower().endswith((".bed", ".bed.gz", ".bed.parquet")):
             phenotype_df, phenotype_pos_df = read_phenotype_bed(args.phenotypes)
         else:
-            if args.phenotypes.endswith('.parquet'):
+            if args.phenotypes.endswith(".parquet"):
                 phenotype_df = pd.read_parquet(args.phenotypes)
             else:  # assume tab-delimited
-                phenotype_df = pd.read_csv(args.phenotypes, sep='\t', index_col=0)
+                phenotype_df = pd.read_csv(args.phenotypes, sep="\t", index_col=0)
             phenotype_pos_df = None
+    else:
+        raise ValueError(f"Unsupported mode: {args.mode}")
 
     if args.covariates is not None:
-        logger.write(f'  * reading covariates ({args.covariates})')
-        covariates_df = pd.read_csv(args.covariates, sep='\t', index_col=0).T
+        logger.write(f"  * reading covariates ({args.covariates})")
+        covariates_df = pd.read_csv(args.covariates, sep="\t", index_col=0).T
         assert phenotype_df.columns.equals(covariates_df.index)
     else:
         covariates_df = None
 
     if args.paired_covariate is not None:
-        assert covariates_df is not None, f"Covariates matrix must be provided when using paired covariate"
-        paired_covariate_df = pd.read_csv(args.paired_covariate, sep='\t', index_col=0)  # phenotypes x samples
-        assert paired_covariate_df.index.isin(phenotype_df.index).all(), f"Paired covariate phenotypes must be present in phenotype matrix."
-        assert paired_covariate_df.columns.equals(phenotype_df.columns), f"Paired covariate samples must match samples in phenotype matrix."
+        assert covariates_df is not None, (
+            "Covariates matrix must be provided when using paired covariate"
+        )
+        paired_covariate_df = pd.read_csv(
+            args.paired_covariate, sep="\t", index_col=0
+        )  # phenotypes x samples
+        assert paired_covariate_df.index.isin(phenotype_df.index).all(), (
+            "Paired covariate phenotypes must be present in phenotype matrix."
+        )
+        assert paired_covariate_df.columns.equals(phenotype_df.columns), (
+            "Paired covariate samples must match samples in phenotype matrix."
+        )
     else:
         paired_covariate_df = None
 
     if args.interaction is not None:
-        logger.write(f'  * reading interaction term(s) ({args.interaction})')
+        logger.write(f"  * reading interaction term(s) ({args.interaction})")
         # allow headerless input for single interactions
         with open(args.interaction) as f:
             f.readline()
             s = f.readline().strip()
-        if len(s.split('\t')) == 2:  # index + value
-            interaction_df = pd.read_csv(args.interaction, sep='\t', index_col=0, header=None)
+        if len(s.split("\t")) == 2:  # index + value
+            interaction_df = pd.read_csv(
+                args.interaction, sep="\t", index_col=0, header=None
+            )
         else:
-            interaction_df = pd.read_csv(args.interaction, sep='\t', index_col=0)
+            interaction_df = pd.read_csv(args.interaction, sep="\t", index_col=0)
         # select samples
         assert covariates_df.index.isin(interaction_df.index).all()
         interaction_df = interaction_df.loc[covariates_df.index].astype(np.float32)
@@ -120,7 +266,7 @@ def main():
         interaction_df = None
 
     if args.maf_threshold is None:
-        if args.mode == 'trans':
+        if args.mode == "trans":
             maf_threshold = 0.05
         else:
             maf_threshold = 0
@@ -128,187 +274,426 @@ def main():
         maf_threshold = args.maf_threshold
 
     if args.phenotype_groups is not None:
-        group_s = pd.read_csv(args.phenotype_groups, sep='\t', index_col=0, header=None).squeeze('columns').rename(None)
+        group_s = (
+            pd.read_csv(args.phenotype_groups, sep="\t", index_col=0, header=None)
+            .squeeze("columns")
+            .rename(None)
+        )
         # verify sort order
         group_dict = group_s.to_dict()
-        previous_group = ''
+        previous_group = ""
         parsed_groups = 0
         for i in phenotype_df.index:
             if group_dict[i] != previous_group:
                 parsed_groups += 1
                 previous_group = group_dict[i]
         if not parsed_groups == len(group_s.unique()):
-            raise ValueError('Groups defined in input do not match phenotype file (check sort order).')
+            raise ValueError(
+                "Groups defined in input do not match phenotype file (check sort order)."
+            )
     else:
         group_s = None
 
     # load genotypes
     if args.chunk_size is None:  # load all genotypes into memory
-        logger.write(f'  * loading genotype dosages' if args.dosages else f'  * loading genotypes')
-        genotype_df, variant_df = genotypeio.load_genotypes(args.genotype_path, select_samples=phenotype_df.columns, dosages=args.dosages)
+        logger.write(
+            "  * loading genotype dosages" if args.dosages else "  * loading genotypes"
+        )
+        genotype_df, variant_df = genotypeio.load_genotypes(
+            args.genotype_path,
+            select_samples=phenotype_df.columns.to_list(),
+            dosages=args.dosages,
+        )
         if variant_df is None:
-            assert not args.mode.startswith('cis'), f"Genotype data without variant positions is only supported for mode='trans'."
+            assert not args.mode.startswith("cis"), (
+                "Genotype data without variant positions is only supported for mode='trans'."
+            )
     else:
-        if not all([os.path.exists(f"{args.genotype_path}.{ext}") for ext in ['pgen', 'psam', 'pvar']]):
-            raise ValueError("Processing in chunks requires PLINK 2 pgen/psam/pvar files.")
+        if not all(
+            [
+                os.path.exists(f"{args.genotype_path}.{ext}")
+                for ext in ["pgen", "psam", "pvar"]
+            ]
+        ):
+            raise ValueError(
+                "Processing in chunks requires PLINK 2 pgen/psam/pvar files."
+            )
         import pgen
-        pgr = pgen.PgenReader(args.genotype_path, select_samples=phenotype_df.columns)
 
-    if args.mode == 'cis':
+        pgr = pgen.PgenReader(
+            args.genotype_path, select_samples=phenotype_df.columns.to_list()
+        )
+
+    if args.mode == "cis":
         if args.chunk_size is None:
-            res_df = cis.map_cis(genotype_df, variant_df, phenotype_df, phenotype_pos_df, covariates_df=covariates_df,
-                                 group_s=group_s, paired_covariate_df=paired_covariate_df, nperm=args.permutations,
-                                 window=args.window, beta_approx=not args.disable_beta_approx, maf_threshold=maf_threshold,
-                                 warn_monomorphic=args.warn_monomorphic, logger=logger, seed=args.seed, verbose=True)
+            res_df = cis.map_cis(
+                genotype_df,
+                variant_df,
+                phenotype_df,
+                phenotype_pos_df,
+                covariates_df=covariates_df,
+                group_s=group_s,
+                paired_covariate_df=paired_covariate_df,
+                nperm=args.permutations,
+                window=args.window,
+                beta_approx=not args.disable_beta_approx,
+                maf_threshold=maf_threshold,
+                warn_monomorphic=args.warn_monomorphic,
+                logger=logger,
+                seed=args.seed,
+                verbose=True,
+            )
         else:
             res_df = []
-            for gt_df, var_df, p_df, p_pos_df, _ in genotypeio.generate_paired_chunks(pgr, phenotype_df, phenotype_pos_df, args.chunk_size,
-                                                                                   dosages=args.dosages, verbose=True):
-                res_df.append(cis.map_cis(gt_df, var_df, p_df, p_pos_df, covariates_df=covariates_df,
-                                          group_s=group_s, paired_covariate_df=paired_covariate_df, nperm=args.permutations,
-                                          window=args.window, beta_approx=not args.disable_beta_approx, maf_threshold=maf_threshold,
-                                          warn_monomorphic=args.warn_monomorphic, logger=logger, seed=args.seed, verbose=True))
+            for gt_df, var_df, p_df, p_pos_df, _ in genotypeio.generate_paired_chunks(
+                pgr,
+                phenotype_df,
+                phenotype_pos_df,
+                args.chunk_size,
+                dosages=args.dosages,
+                verbose=True,
+            ):
+                res_df.append(
+                    cis.map_cis(
+                        gt_df,
+                        var_df,
+                        p_df,
+                        p_pos_df,
+                        covariates_df=covariates_df,
+                        group_s=group_s,
+                        paired_covariate_df=paired_covariate_df,
+                        nperm=args.permutations,
+                        window=args.window,
+                        beta_approx=not args.disable_beta_approx,
+                        maf_threshold=maf_threshold,
+                        warn_monomorphic=args.warn_monomorphic,
+                        logger=logger,
+                        seed=args.seed,
+                        verbose=True,
+                    )
+                )
             res_df = pd.concat(res_df)
-        logger.write('  * writing output')
+        logger.write("  * writing output")
         if has_rpy2:
-            calculate_qvalues(res_df, fdr=args.fdr, qvalue_lambda=args.qvalue_lambda, logger=logger)
-        out_file = os.path.join(args.output_dir, f'{args.prefix}.cis_qtl.txt.gz')
-        res_df.to_csv(out_file, sep='\t', float_format='%.6g')
+            calculate_qvalues(
+                res_df, fdr=args.fdr, qvalue_lambda=args.qvalue_lambda, logger=logger
+            )
+        out_file = os.path.join(args.output_dir, f"{args.prefix}.cis_qtl.txt.gz")
+        res_df.to_csv(out_file, sep="\t", float_format="%.6g")
 
-    elif args.mode == 'cis_nominal':
+    elif args.mode == "cis_nominal":
         if args.chunk_size is None:
-            cis.map_nominal(genotype_df, variant_df, phenotype_df, phenotype_pos_df, args.prefix, covariates_df=covariates_df,
-                            paired_covariate_df=paired_covariate_df, interaction_df=interaction_df,
-                            maf_threshold_interaction=args.maf_threshold_interaction,
-                            group_s=None, window=args.window, maf_threshold=maf_threshold, run_eigenmt=True,
-                            output_dir=args.output_dir, write_top=True, write_stats=not args.best_only, logger=logger, verbose=True)
+            cis.map_nominal(
+                genotype_df,
+                variant_df,
+                phenotype_df,
+                phenotype_pos_df,
+                args.prefix,
+                covariates_df=covariates_df,
+                paired_covariate_df=paired_covariate_df,
+                interaction_df=interaction_df,
+                maf_threshold_interaction=args.maf_threshold_interaction,
+                group_s=None,
+                window=args.window,
+                maf_threshold=maf_threshold,
+                run_eigenmt=True,
+                output_dir=args.output_dir,
+                write_top=True,
+                write_stats=not args.best_only,
+                logger=logger,
+                verbose=True,
+            )
             # compute significant pairs
             if args.cis_output is not None:
-                cis_df = pd.read_csv(args.cis_output, sep='\t', index_col=0)
-                nominal_prefix = os.path.join(args.output_dir, f'{args.prefix}.cis_qtl_pairs')
-                signif_df = get_significant_pairs(cis_df, nominal_prefix, group_s=group_s, fdr=args.fdr)
-                signif_df.to_parquet(os.path.join(args.output_dir, f'{args.prefix}.cis_qtl.signif_pairs.parquet'))
+                cis_df = pd.read_csv(args.cis_output, sep="\t", index_col=0)
+                nominal_prefix = os.path.join(
+                    args.output_dir, f"{args.prefix}.cis_qtl_pairs"
+                )
+                signif_df = get_significant_pairs(
+                    cis_df, nominal_prefix, group_s=group_s, fdr=args.fdr
+                )
+                signif_df.to_parquet(
+                    os.path.join(
+                        args.output_dir, f"{args.prefix}.cis_qtl.signif_pairs.parquet"
+                    )
+                )
 
         else:
             chunks = []
-            for gt_df, var_df, p_df, p_pos_df, ci in genotypeio.generate_paired_chunks(pgr, phenotype_df, phenotype_pos_df, args.chunk_size,
-                                                                                       dosages=args.dosages, verbose=True):
-                prefix = f"{args.prefix}.chunk{ci+1}"
+            for gt_df, var_df, p_df, p_pos_df, ci in genotypeio.generate_paired_chunks(
+                pgr,
+                phenotype_df,
+                phenotype_pos_df,
+                args.chunk_size,
+                dosages=args.dosages,
+                verbose=True,
+            ):
+                prefix = f"{args.prefix}.chunk{ci + 1}"
                 chunks.append(prefix)
-                cis.map_nominal(gt_df, var_df, p_df, p_pos_df, prefix, covariates_df=covariates_df,
-                                paired_covariate_df=paired_covariate_df, interaction_df=interaction_df,
-                                maf_threshold_interaction=args.maf_threshold_interaction,
-                                group_s=None, window=args.window, maf_threshold=maf_threshold, run_eigenmt=True,
-                                output_dir=args.output_dir, write_top=True, write_stats=not args.best_only, logger=logger, verbose=True)
-            chunk_files = glob.glob(os.path.join(args.output_dir, f"{args.prefix}.chunk*.cis_qtl_pairs.*.parquet"))
-            if args.chunk_size == 'chr':  # remove redundant chunk ID from file names
+                cis.map_nominal(
+                    gt_df,
+                    var_df,
+                    p_df,
+                    p_pos_df,
+                    prefix,
+                    covariates_df=covariates_df,
+                    paired_covariate_df=paired_covariate_df,
+                    interaction_df=interaction_df,
+                    maf_threshold_interaction=args.maf_threshold_interaction,
+                    group_s=None,
+                    window=args.window,
+                    maf_threshold=maf_threshold,
+                    run_eigenmt=True,
+                    output_dir=args.output_dir,
+                    write_top=True,
+                    write_stats=not args.best_only,
+                    logger=logger,
+                    verbose=True,
+                )
+            chunk_files = glob.glob(
+                os.path.join(
+                    args.output_dir, f"{args.prefix}.chunk*.cis_qtl_pairs.*.parquet"
+                )
+            )
+            if args.chunk_size == "chr":  # remove redundant chunk ID from file names
                 for f in chunk_files:
-                    x = re.findall(f"{args.prefix}\.(chunk\d+)", os.path.basename(f))
+                    x = re.findall(rf"{args.prefix}\.(chunk\d+)", os.path.basename(f))
                     assert len(x) == 1
                     os.rename(f, f.replace(f"{x[0]}.", ""))
             else:  # concatenate outputs by chromosome
-                chunk_df = pd.DataFrame({
-                    'file': chunk_files,
-                    'chunk': [int(re.findall(f"{args.prefix}\.chunk(\d+)", os.path.basename(i))[0]) for i in chunk_files],
-                    'chr': [re.findall("\.cis_qtl_pairs\.(.*)\.parquet", os.path.basename(i))[0] for i in chunk_files],
-                }).sort_values('chunk')
-                for chrom, chr_df in chunk_df.groupby('chr', sort=False):
-                    print(f"\rConcatenating outputs for {chrom}", end='' if chrom != chunk_df['chr'].iloc[-1] else None)
-                    pd.concat([pd.read_parquet(f) for f in chr_df['file']]).reset_index(drop=True).to_parquet(
-                        os.path.join(args.output_dir, f"{args.prefix}.cis_qtl_pairs.{chrom}.parquet"))
-                    for f in chr_df['file']:
+                chunk_df = pd.DataFrame(
+                    {
+                        "file": chunk_files,
+                        "chunk": [
+                            int(
+                                re.findall(
+                                    rf"{args.prefix}\.chunk(\d+)", os.path.basename(i)
+                                )[0]
+                            )
+                            for i in chunk_files
+                        ],
+                        "chr": [
+                            re.findall(
+                                r"\.cis_qtl_pairs\.(.*)\.parquet", os.path.basename(i)
+                            )[0]
+                            for i in chunk_files
+                        ],
+                    }
+                ).sort_values("chunk")
+                for chrom, chr_df in chunk_df.groupby("chr", sort=False):
+                    print(
+                        f"\rConcatenating outputs for {chrom}",
+                        end="" if chrom != chunk_df["chr"].iloc[-1] else None,
+                    )
+                    pd.concat([pd.read_parquet(f) for f in chr_df["file"]]).reset_index(
+                        drop=True
+                    ).to_parquet(
+                        os.path.join(
+                            args.output_dir,
+                            f"{args.prefix}.cis_qtl_pairs.{chrom}.parquet",
+                        )
+                    )
+                    for f in chr_df["file"]:
                         os.remove(f)
             # concatenate interaction results
             if interaction_df is not None:
-                chunk_files = [os.path.join(args.output_dir, f"{c}.cis_qtl_top_assoc.txt.gz") for c in chunks]
-                pd.concat([pd.read_csv(f, sep='\t', index_col=0, dtype=str) for f in chunk_files]).to_csv(
-                    os.path.join(args.output_dir, f"{args.prefix}.cis_qtl_top_assoc.txt.gz"), sep='\t')
+                chunk_files = [
+                    os.path.join(args.output_dir, f"{c}.cis_qtl_top_assoc.txt.gz")
+                    for c in chunks
+                ]
+                pd.concat(
+                    [
+                        pd.read_csv(f, sep="\t", index_col=0, dtype=str)
+                        for f in chunk_files
+                    ]
+                ).to_csv(
+                    os.path.join(
+                        args.output_dir, f"{args.prefix}.cis_qtl_top_assoc.txt.gz"
+                    ),
+                    sep="\t",
+                )
                 for f in chunk_files:
                     os.remove(f)
 
-    elif args.mode == 'cis_independent':
-        summary_df = pd.read_csv(args.cis_output, sep='\t', index_col=0)
-        summary_df.rename(columns={'minor_allele_samples':'ma_samples', 'minor_allele_count':'ma_count'}, inplace=True)
+    elif args.mode == "cis_independent":
+        summary_df = pd.read_csv(args.cis_output, sep="\t", index_col=0)
+        summary_df.rename(
+            columns={
+                "minor_allele_samples": "ma_samples",
+                "minor_allele_count": "ma_count",
+            },
+            inplace=True,
+        )
         if args.chunk_size is None:
-            res_df = cis.map_independent(genotype_df, variant_df, summary_df, phenotype_df, phenotype_pos_df, covariates_df=covariates_df,
-                                         group_s=group_s, fdr=args.fdr, nperm=args.permutations, window=args.window,
-                                         maf_threshold=maf_threshold, logger=logger, seed=args.seed, verbose=True)
+            res_df = cis.map_independent(
+                genotype_df,
+                variant_df,
+                summary_df,
+                phenotype_df,
+                phenotype_pos_df,
+                covariates_df=covariates_df,
+                group_s=group_s,
+                fdr=args.fdr,
+                nperm=args.permutations,
+                window=args.window,
+                maf_threshold=maf_threshold,
+                logger=logger,
+                seed=args.seed,
+                verbose=True,
+            )
         else:
             res_df = []
-            for gt_df, var_df, p_df, p_pos_df, _ in genotypeio.generate_paired_chunks(pgr, phenotype_df, phenotype_pos_df, args.chunk_size,
-                                                                                      dosages=args.dosages, verbose=True):
-                res_df.append(cis.map_independent(gt_df, var_df, summary_df, p_df, p_pos_df, covariates_df=covariates_df,
-                                                  group_s=group_s, fdr=args.fdr, nperm=args.permutations, window=args.window,
-                                                  maf_threshold=maf_threshold, logger=logger, seed=args.seed, verbose=True))
+            for gt_df, var_df, p_df, p_pos_df, _ in genotypeio.generate_paired_chunks(
+                pgr,
+                phenotype_df,
+                phenotype_pos_df,
+                args.chunk_size,
+                dosages=args.dosages,
+                verbose=True,
+            ):
+                res_df.append(
+                    cis.map_independent(
+                        gt_df,
+                        var_df,
+                        summary_df,
+                        p_df,
+                        p_pos_df,
+                        covariates_df=covariates_df,
+                        group_s=group_s,
+                        fdr=args.fdr,
+                        nperm=args.permutations,
+                        window=args.window,
+                        maf_threshold=maf_threshold,
+                        logger=logger,
+                        seed=args.seed,
+                        verbose=True,
+                    )
+                )
             res_df = pd.concat(res_df).reset_index(drop=True)
-        logger.write('  * writing output')
-        out_file = os.path.join(args.output_dir, f'{args.prefix}.cis_independent_qtl.txt.gz')
-        res_df.to_csv(out_file, sep='\t', index=False, float_format='%.6g')
+        logger.write("  * writing output")
+        out_file = os.path.join(
+            args.output_dir, f"{args.prefix}.cis_independent_qtl.txt.gz"
+        )
+        res_df.to_csv(out_file, sep="\t", index=False, float_format="%.6g")
 
-    elif args.mode == 'cis_susie':
-        if args.cis_output.endswith('.parquet'):
+    elif args.mode == "cis_susie":
+        if args.cis_output.endswith(".parquet"):
             signif_df = pd.read_parquet(args.cis_output)
         else:
-            signif_df = pd.read_csv(args.cis_output, sep='\t')
-        if 'qval' in signif_df:  # otherwise input is from get_significant_pairs
-            signif_df = signif_df[signif_df['qval'] <= args.fdr]
-        phenotype_ids = phenotype_df.index[phenotype_df.index.isin(signif_df['phenotype_id'].unique())]
+            signif_df = pd.read_csv(args.cis_output, sep="\t")
+        if "qval" in signif_df:  # otherwise input is from get_significant_pairs
+            signif_df = signif_df[signif_df["qval"] <= args.fdr]
+        phenotype_ids = phenotype_df.index[
+            phenotype_df.index.isin(signif_df["phenotype_id"].unique())
+        ]
         phenotype_df = phenotype_df.loc[phenotype_ids]
         phenotype_pos_df = phenotype_pos_df.loc[phenotype_ids]
         if args.chunk_size is None:
-            summary_df, res = susie.map(genotype_df, variant_df, phenotype_df, phenotype_pos_df,
-                                        covariates_df, paired_covariate_df=paired_covariate_df, L=args.max_effects,
-                                        maf_threshold=maf_threshold, max_iter=500, window=args.window, summary_only=False)
+            summary_df, res = susie.map(
+                genotype_df,
+                variant_df,
+                phenotype_df,
+                phenotype_pos_df,
+                covariates_df,
+                paired_covariate_df=paired_covariate_df,
+                L=args.max_effects,
+                maf_threshold=maf_threshold,
+                max_iter=500,
+                window=args.window,
+                summary_only=False,
+            )
         else:
             summary_df = []
             res = {}
-            for gt_df, var_df, p_df, p_pos_df, _ in genotypeio.generate_paired_chunks(pgr, phenotype_df, phenotype_pos_df, args.chunk_size,
-                                                                                      dosages=args.dosages, verbose=True):
-                chunk_summary_df, chunk_res = susie.map(gt_df, var_df, p_df, p_pos_df,
-                                                        covariates_df, paired_covariate_df=paired_covariate_df, L=args.max_effects,
-                                                        maf_threshold=maf_threshold, max_iter=500, window=args.window, summary_only=False)
+            for gt_df, var_df, p_df, p_pos_df, _ in genotypeio.generate_paired_chunks(
+                pgr,
+                phenotype_df,
+                phenotype_pos_df,
+                args.chunk_size,
+                dosages=args.dosages,
+                verbose=True,
+            ):
+                chunk_summary_df, chunk_res = susie.map(
+                    gt_df,
+                    var_df,
+                    p_df,
+                    p_pos_df,
+                    covariates_df,
+                    paired_covariate_df=paired_covariate_df,
+                    L=args.max_effects,
+                    maf_threshold=maf_threshold,
+                    max_iter=500,
+                    window=args.window,
+                    summary_only=False,
+                )
                 summary_df.append(chunk_summary_df)
                 res |= chunk_res
             summary_df = pd.concat(summary_df).reset_index(drop=True)
 
-        summary_df.to_parquet(os.path.join(args.output_dir, f'{args.prefix}.SuSiE_summary.parquet'))
-        with open(os.path.join(args.output_dir, f'{args.prefix}.SuSiE.pickle'), 'wb') as f:
+        summary_df.to_parquet(
+            os.path.join(args.output_dir, f"{args.prefix}.SuSiE_summary.parquet")
+        )
+        with open(
+            os.path.join(args.output_dir, f"{args.prefix}.SuSiE.pickle"), "wb"
+        ) as f:
             pickle.dump(res, f)
 
-    elif args.mode == 'trans_susie':
+    elif args.mode == "trans_susie":
         assert args.susie_loci is not None
-        if args.susie_loci.endswith('.parquet'):
+        if args.susie_loci.endswith(".parquet"):
             locus_df = pd.read_parquet(args.susie_loci)
         else:
-            locus_df = pd.read_csv(args.susie_loci, sep='\t')
-        locus_df.rename(columns={'position':'pos'}, inplace=True)
+            locus_df = pd.read_csv(args.susie_loci, sep="\t")
+        locus_df.rename(columns={"position": "pos"}, inplace=True)
         if args.chunk_size is None:
             assert variant_df is not None
-            summary_df, res = susie.map_loci(locus_df, genotype_df, variant_df, phenotype_df, covariates_df,
-                                             maf_threshold=maf_threshold, max_iter=500, window=args.window)
+            summary_df, res = susie.map_loci(
+                locus_df,
+                genotype_df,
+                variant_df,
+                phenotype_df,
+                covariates_df,
+                maf_threshold=maf_threshold,
+                max_iter=500,
+                window=args.window,
+            )
         else:
             raise NotImplementedError()
 
-        summary_df.to_parquet(os.path.join(args.output_dir, f'{args.prefix}.SuSiE_summary.parquet'))
-        with open(os.path.join(args.output_dir, f'{args.prefix}.SuSiE.pickle'), 'wb') as f:
+        summary_df.to_parquet(
+            os.path.join(args.output_dir, f"{args.prefix}.SuSiE_summary.parquet")
+        )
+        with open(
+            os.path.join(args.output_dir, f"{args.prefix}.SuSiE.pickle"), "wb"
+        ) as f:
             pickle.dump(res, f)
 
-    elif args.mode == 'trans':
+    elif args.mode == "trans":
         return_sparse = not args.return_dense
         if return_sparse:
-            logger.write(f'  * p-value threshold: {args.pval_threshold:.2g}')
+            logger.write(f"  * p-value threshold: {args.pval_threshold:.2g}")
 
         if interaction_df is not None:
             if interaction_df.shape[1] > 1:
-                raise NotImplementedError('trans-QTL mapping currently only supports a single interaction.')
+                raise NotImplementedError(
+                    "trans-QTL mapping currently only supports a single interaction."
+                )
             else:
-                interaction_df = interaction_df.squeeze('columns')
+                interaction_df = interaction_df.squeeze("columns")
 
         if args.chunk_size is None:
-            pairs_df = trans.map_trans(genotype_df, phenotype_df, covariates_df=covariates_df, interaction_s=interaction_df,
-                                       return_sparse=return_sparse, pval_threshold=args.pval_threshold,
-                                       maf_threshold=maf_threshold, batch_size=args.batch_size,
-                                       return_r2=args.return_r2, logger=logger)
+            pairs_df = trans.map_trans(
+                genotype_df,
+                phenotype_df,
+                covariates_df=covariates_df,
+                interaction_s=interaction_df,
+                return_sparse=return_sparse,
+                pval_threshold=args.pval_threshold,
+                maf_threshold=maf_threshold,
+                batch_size=args.batch_size,
+                return_r2=args.return_r2,
+                logger=logger,
+            )
             if args.return_dense:
                 pval_df, b_df, b_se_df, af_s = pairs_df
         else:
@@ -318,40 +703,72 @@ def main():
             if rem != 0:
                 bounds.append(rem)
             bounds = np.cumsum(bounds)
-            nchunks = len(bounds)-1
+            nchunks = len(bounds) - 1
             for i in range(nchunks):
-                print(f"Processing genotype chunk {i+1}/{nchunks}")
+                print(f"Processing genotype chunk {i + 1}/{nchunks}")
                 if args.dosages:
-                    gt_df = pgr.read_dosages_range(bounds[i], bounds[i+1]-1, dtype=np.float32)
+                    gt_df = pgr.read_dosages_range(
+                        bounds[i], bounds[i + 1] - 1, dtype=np.float32
+                    )
                 else:
-                    gt_df = pgr.read_range(bounds[i], bounds[i+1]-1, impute_mean=False, dtype=np.int8)
-                pairs_df.append(trans.map_trans(gt_df, phenotype_df, covariates_df=covariates_df, interaction_s=interaction_df,
-                                                return_sparse=return_sparse, pval_threshold=args.pval_threshold,
-                                                maf_threshold=maf_threshold, batch_size=args.batch_size,
-                                                return_r2=args.return_r2, logger=logger))
+                    gt_df = pgr.read_range(
+                        bounds[i], bounds[i + 1] - 1, impute_mean=False, dtype=np.int8
+                    )
+                pairs_df.append(
+                    trans.map_trans(
+                        gt_df,
+                        phenotype_df,
+                        covariates_df=covariates_df,
+                        interaction_s=interaction_df,
+                        return_sparse=return_sparse,
+                        pval_threshold=args.pval_threshold,
+                        maf_threshold=maf_threshold,
+                        batch_size=args.batch_size,
+                        return_r2=args.return_r2,
+                        logger=logger,
+                    )
+                )
             pairs_df = pd.concat(pairs_df).reset_index(drop=True)
             variant_df = pgr.variant_df
 
         if return_sparse:
             if variant_df is not None and phenotype_pos_df is not None:
-                logger.write('  * filtering out cis-QTLs (within +/-5Mb)')
-                pairs_df = trans.filter_cis(pairs_df, phenotype_pos_df, variant_df, window=5000000)
+                logger.write("  * filtering out cis-QTLs (within +/-5Mb)")
+                pairs_df = trans.filter_cis(
+                    pairs_df, phenotype_pos_df, variant_df, window=5000000
+                )
 
-            logger.write('  * writing sparse output')
+            logger.write("  * writing sparse output")
             if not args.output_text:
-                pairs_df.to_parquet(os.path.join(args.output_dir, f'{args.prefix}.trans_qtl_pairs.parquet'))
+                pairs_df.to_parquet(
+                    os.path.join(
+                        args.output_dir, f"{args.prefix}.trans_qtl_pairs.parquet"
+                    )
+                )
             else:
-                out_file = os.path.join(args.output_dir, f'{args.prefix}.trans_qtl_pairs.txt.gz')
-                pairs_df.to_csv(out_file, sep='\t', index=False, float_format='%.6g')
+                out_file = os.path.join(
+                    args.output_dir, f"{args.prefix}.trans_qtl_pairs.txt.gz"
+                )
+                pairs_df.to_csv(out_file, sep="\t", index=False, float_format="%.6g")
         else:
-            logger.write('  * writing dense output')
-            pval_df.to_parquet(os.path.join(args.output_dir, f'{args.prefix}.trans_qtl_pval.parquet'))
-            b_df.to_parquet(os.path.join(args.output_dir, f'{args.prefix}.trans_qtl_beta.parquet'))
-            b_se_df.to_parquet(os.path.join(args.output_dir, f'{args.prefix}.trans_qtl_beta_se.parquet'))
-            af_s.to_frame().to_parquet(os.path.join(args.output_dir, f'{args.prefix}.trans_qtl_af.parquet'))
+            logger.write("  * writing dense output")
+            pval_df.to_parquet(
+                os.path.join(args.output_dir, f"{args.prefix}.trans_qtl_pval.parquet")
+            )
+            b_df.to_parquet(
+                os.path.join(args.output_dir, f"{args.prefix}.trans_qtl_beta.parquet")
+            )
+            b_se_df.to_parquet(
+                os.path.join(
+                    args.output_dir, f"{args.prefix}.trans_qtl_beta_se.parquet"
+                )
+            )
+            af_s.to_frame().to_parquet(
+                os.path.join(args.output_dir, f"{args.prefix}.trans_qtl_af.parquet")
+            )
 
-    logger.write(f'[{datetime.now().strftime("%b %d %H:%M:%S")}] Finished mapping')
+    logger.write(f"[{datetime.now().strftime('%b %d %H:%M:%S')}] Finished mapping")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary

This PR adds type annotations to public APIs and CLI-facing entrypoints, and includes a few low-risk cleanups surfaced during the process.

## Changes

- add type annotations in `core.py`, `post.py`, `pgen.py`, `genotypeio.py`, and `tensorqtl.py`
- replace selected star imports with explicit imports in CLI and post-processing entrypoints
- fix a few small typing-related issues without changing algorithms or output formats

## Validation

Checked locally with import/CLI and lightweight smoke tests covering:

- `import tensorqtl`
- `python -m tensorqtl --help`
- `read_phenotype_bed(...)`
- `PgenReader(...)` and genotype loading paths
